### PR TITLE
test(e2e): improvements

### DIFF
--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -16,7 +16,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distribtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
 	paramsproptypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
@@ -44,12 +46,16 @@ func init() {
 	authtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	authvesting.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	stakingtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	slashingtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	evidencetypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	cryptocodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	feegrant.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	govv1types.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	govv1beta1types.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	paramsproptypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	paramsproptypes.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	feegrant.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	slashingtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 
 	upgradetypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	distribtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)

--- a/tests/e2e/chain.go
+++ b/tests/e2e/chain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -37,6 +38,8 @@ var (
 
 func init() {
 	encodingConfig = atomoneparams.MakeEncodingConfig()
+	sdk.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	tx.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	banktypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	authtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	authvesting.RegisterInterfaces(encodingConfig.InterfaceRegistry)

--- a/tests/e2e/e2e_bank_test.go
+++ b/tests/e2e/e2e_bank_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *IntegrationTestSuite) testBankTokenTransfer() {
-	s.Run("send_tokens_between_accounts", func() {
+	s.Run("send tokens between accounts", func() {
 		var (
 			err           error
 			valIdx        = 0

--- a/tests/e2e/e2e_bank_test.go
+++ b/tests/e2e/e2e_bank_test.go
@@ -43,7 +43,7 @@ func (s *IntegrationTestSuite) testBankTokenTransfer() {
 				return beforeAliceUAtoneBalance.IsValid() && beforeBobUAtoneBalance.IsValid() && beforeCharlieUAtoneBalance.IsValid()
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		// alice sends tokens to bob
@@ -64,7 +64,7 @@ func (s *IntegrationTestSuite) testBankTokenTransfer() {
 				return decremented && incremented
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		// save the updated account balances of alice and bob
@@ -92,7 +92,7 @@ func (s *IntegrationTestSuite) testBankTokenTransfer() {
 				return decremented && incremented
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 	})
 }

--- a/tests/e2e/e2e_distribution_test.go
+++ b/tests/e2e/e2e_distribution_test.go
@@ -40,7 +40,7 @@ func (s *IntegrationTestSuite) testDistribution() {
 				return res.WithdrawAddress == newWithdrawalAddress.String()
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		s.execWithdrawReward(s.chainA, 0, delegatorAddress.String(), valOperAddressA, atomoneHomePath)
@@ -52,7 +52,7 @@ func (s *IntegrationTestSuite) testDistribution() {
 				return afterBalance.IsGTE(beforeBalance)
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 	})
 }
@@ -86,9 +86,9 @@ func (s *IntegrationTestSuite) fundCommunityPool() {
 			afterDistPhotonBalance, err := getSpecificBalance(chainAAPIEndpoint, distModuleAddress, tokenAmount.Denom)
 			s.Require().NoErrorf(err, "Error getting balance: %s", afterDistPhotonBalance)
 
-			return afterDistPhotonBalance.Sub(beforeDistUatoneBalance.Add(tokenAmount.Add(standardFees))).IsLT(marginOfErrorForBlockReward)
+			return beforeDistUatoneBalance.Add(tokenAmount.Add(standardFees)).Sub(afterDistPhotonBalance).IsLT(marginOfErrorForBlockReward)
 		},
 		15*time.Second,
-		5*time.Second,
+		time.Second,
 	)
 }

--- a/tests/e2e/e2e_evidence_test.go
+++ b/tests/e2e/e2e_evidence_test.go
@@ -9,8 +9,8 @@ import (
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 )
 
-func (s *IntegrationTestSuite) testEvidence() {
-	s.Run("test evidence queries", func() {
+func (s *IntegrationTestSuite) testEvidenceQueries() {
+	s.Run("queries", func() {
 		var (
 			valIdx   = 0
 			chain    = s.chainA

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -579,12 +579,22 @@ func (s *IntegrationTestSuite) execRedelegate(c *chain, valIdx int, amount, orig
 	s.T().Logf("%s successfully redelegated %s from %s to %s", delegatorAddr, amount, originalValOperAddress, newValOperAddress)
 }
 
-func (s *IntegrationTestSuite) getLatestBlockHeight(c *chain, valIdx int) int {
-	rpcClient, err := rpchttp.New("tcp://"+s.valResources[c.id][valIdx].GetHostPort("26657/tcp"), "/websocket")
+func (s *IntegrationTestSuite) rpcClient(c *chain, valIdx int) *rpchttp.HTTP {
+	rc, err := rpchttp.New("tcp://"+s.valResources[c.id][valIdx].GetHostPort("26657/tcp"), "/websocket")
 	s.Require().NoError(err)
-	status, err := rpcClient.Status(context.Background())
+	return rc
+}
+
+func (s *IntegrationTestSuite) getLatestBlockHeight(c *chain, valIdx int) int64 {
+	status, err := s.rpcClient(c, valIdx).Status(context.Background())
 	s.Require().NoError(err)
-	return int(status.SyncInfo.LatestBlockHeight)
+	return status.SyncInfo.LatestBlockHeight
+}
+
+func (s *IntegrationTestSuite) getLatestBlockTime(c *chain, valIdx int) time.Time {
+	status, err := s.rpcClient(c, valIdx).Status(context.Background())
+	s.Require().NoError(err)
+	return status.SyncInfo.LatestBlockTime
 }
 
 // func (s *IntegrationTestSuite) verifyBalanceChange(endpoint string, expectedAmount sdk.Coin, recipientAddress string) {

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -741,7 +741,13 @@ func (s *IntegrationTestSuite) defaultExecValidation(chain *chain, valIdx int) f
 			endpoint := fmt.Sprintf("http://%s", s.valResources[chain.id][valIdx].GetHostPort("1317/tcp"))
 			s.Require().Eventually(
 				func() bool {
-					return queryAtomOneTx(endpoint, txResp.TxHash) == nil
+					err := queryAtomOneTx(endpoint, txResp.TxHash)
+					if isErrNotFound(err) {
+						// tx not processed yet, continue
+						return false
+					}
+					s.Require().NoError(err)
+					return true
 				},
 				time.Minute,
 				time.Second,

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -613,7 +613,7 @@ func (s *IntegrationTestSuite) getLatestBlockHeight(c *chain, valIdx int) int {
 // 			return afterAtomBalance.IsEqual(expectedAmount)
 // 		},
 // 		20*time.Second,
-// 		5*time.Second,
+// 		time.Second,
 // 	)
 // }
 
@@ -730,7 +730,7 @@ func (s *IntegrationTestSuite) expectErrExecValidation(chain *chain, valIdx int,
 				return gotErr == expectErr
 			},
 			time.Minute,
-			5*time.Second,
+			time.Second,
 			"stdOut: %s, stdErr: %s",
 			string(stdOut), string(stdErr),
 		)
@@ -751,7 +751,7 @@ func (s *IntegrationTestSuite) defaultExecValidation(chain *chain, valIdx int) f
 					return queryAtomOneTx(endpoint, txResp.TxHash) == nil
 				},
 				time.Minute,
-				5*time.Second,
+				time.Second,
 				"stdOut: %s, stdErr: %s",
 				string(stdOut), string(stdErr),
 			)

--- a/tests/e2e/e2e_feegrant_test.go
+++ b/tests/e2e/e2e_feegrant_test.go
@@ -18,7 +18,7 @@ import (
 //
 //	*/
 func (s *IntegrationTestSuite) testFeeGrant() {
-	s.Run("test fee grant module", func() {
+	s.Run("fee grant module", func() {
 		var (
 			valIdx = 0
 			c      = s.chainA

--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -60,7 +60,7 @@ func (s *IntegrationTestSuite) testGovSoftwareUpgrade() {
 				return h > 0
 			},
 			30*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		proposalCounter = 0
@@ -147,7 +147,7 @@ func (s *IntegrationTestSuite) testGovCommunityPoolSpend() {
 				return afterRecipientBalance.Sub(sendAmount).IsEqual(beforeRecipientBalance)
 			},
 			10*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 	})
 }
@@ -188,7 +188,7 @@ func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx
 			return currentHeight == upgradeHeight
 		},
 		30*time.Second,
-		5*time.Second,
+		time.Second,
 	)
 
 	counter := 0
@@ -205,7 +205,7 @@ func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx
 			return counter >= 2
 		},
 		8*time.Second,
-		2*time.Second,
+		time.Second,
 	)
 }
 
@@ -217,7 +217,7 @@ func (s *IntegrationTestSuite) verifyChainPassesUpgradeHeight(c *chain, valIdx, 
 			return currentHeight > upgradeHeight
 		},
 		30*time.Second,
-		5*time.Second,
+		time.Second,
 	)
 }
 
@@ -231,6 +231,6 @@ func (s *IntegrationTestSuite) submitGovCommand(chainAAPIEndpoint, sender string
 			return proposal.GetProposal().Status == expectedSuccessStatus
 		},
 		15*time.Second,
-		5*time.Second,
+		time.Second,
 	)
 }

--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -210,14 +210,16 @@ func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx
 }
 
 func (s *IntegrationTestSuite) verifyChainPassesUpgradeHeight(c *chain, valIdx, upgradeHeight int) {
+	var currentHeight int
 	s.Require().Eventually(
 		func() bool {
-			currentHeight := s.getLatestBlockHeight(c, valIdx)
+			currentHeight = s.getLatestBlockHeight(c, valIdx)
 
 			return currentHeight > upgradeHeight
 		},
 		30*time.Second,
 		time.Second,
+		"expected chain height min=%d: got %d", upgradeHeight, currentHeight,
 	)
 }
 

--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -30,8 +30,6 @@ func (s *IntegrationTestSuite) testGovSoftwareUpgrade() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 
-		s.writeGovLegProposal(s.chainA, int64(height), "upgrade-v0")
-
 		submitGovFlags := []string{
 			"software-upgrade",
 			"Upgrade-0",
@@ -39,7 +37,7 @@ func (s *IntegrationTestSuite) testGovSoftwareUpgrade() {
 			"--description='Software Upgrade'",
 			"--no-validate",
 			fmt.Sprintf("--upgrade-height=%d", proposalHeight),
-			fmt.Sprintf("--upgrade-info=%s", configFile(proposalCommunitySpendFilename)),
+			"--upgrade-info=my-info",
 		}
 
 		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
@@ -81,7 +79,6 @@ func (s *IntegrationTestSuite) testGovCancelSoftwareUpgrade() {
 		sender := senderAddress.String()
 		height := s.getLatestBlockHeight(s.chainA, 0)
 		proposalHeight := height + 50
-		s.writeGovLegProposal(s.chainA, int64(height), "upgrade-v1")
 
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
@@ -92,7 +89,6 @@ func (s *IntegrationTestSuite) testGovCancelSoftwareUpgrade() {
 			"--description='Software Upgrade'",
 			"--no-validate",
 			fmt.Sprintf("--upgrade-height=%d", proposalHeight),
-			fmt.Sprintf("--upgrade-info=%s", configFile(proposalCommunitySpendFilename)),
 		}
 
 		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}

--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -175,7 +175,7 @@ func (s *IntegrationTestSuite) submitGovProposal(chainAAPIEndpoint, sender strin
 	s.submitGovCommand(chainAAPIEndpoint, sender, proposalID, voteCommand, voteFlags, govtypesv1beta1.StatusPassed)
 }
 
-func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx, upgradeHeight int) {
+func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx int, upgradeHeight int64) {
 	s.Require().Eventually(
 		func() bool {
 			currentHeight := s.getLatestBlockHeight(c, valIdx)
@@ -204,8 +204,8 @@ func (s *IntegrationTestSuite) verifyChainHaltedAtUpgradeHeight(c *chain, valIdx
 	)
 }
 
-func (s *IntegrationTestSuite) verifyChainPassesUpgradeHeight(c *chain, valIdx, upgradeHeight int) {
-	var currentHeight int
+func (s *IntegrationTestSuite) verifyChainPassesUpgradeHeight(c *chain, valIdx int, upgradeHeight int64) {
+	var currentHeight int64
 	s.Require().Eventually(
 		func() bool {
 			currentHeight = s.getLatestBlockHeight(c, valIdx)

--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -56,8 +56,7 @@ func (s *IntegrationTestSuite) testGovSoftwareUpgrade() {
 
 		s.Require().Eventually(
 			func() bool {
-				h := s.getLatestBlockHeight(s.chainA, 0)
-				return h > 0
+				return s.getLatestBlockHeight(s.chainA, 0) > 0
 			},
 			30*time.Second,
 			time.Second,
@@ -214,12 +213,11 @@ func (s *IntegrationTestSuite) verifyChainPassesUpgradeHeight(c *chain, valIdx, 
 	s.Require().Eventually(
 		func() bool {
 			currentHeight = s.getLatestBlockHeight(c, valIdx)
-
 			return currentHeight > upgradeHeight
 		},
 		30*time.Second,
 		time.Second,
-		"expected chain height min=%d: got %d", upgradeHeight, currentHeight,
+		"expected chain height greater than %d: got %d", upgradeHeight, currentHeight,
 	)
 }
 

--- a/tests/e2e/e2e_rest_regression_test.go
+++ b/tests/e2e/e2e_rest_regression_test.go
@@ -46,7 +46,7 @@ const (
 )
 
 func (s *IntegrationTestSuite) testRestInterfaces() {
-	s.Run("test rest interfaces", func() {
+	s.Run("rest interfaces", func() {
 		var (
 			valIdx        = 0
 			c             = s.chainA

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -27,7 +27,6 @@ import (
 	tmconfig "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	tmjson "github.com/cometbft/cometbft/libs/json"
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -57,7 +56,7 @@ const (
 	initBalanceStr                  = "110000000000stake,100000000000000000photon,100000000000000000uatone"
 	minGasPrice                     = "0.00001"
 	gas                             = 200000
-	govProposalBlockBuffer          = 35
+	govProposalBlockBuffer    int64 = 35
 	relayerAccountIndexHermes       = 0
 	numberOfEvidences               = 10
 	slashingShares            int64 = 10000
@@ -552,9 +551,7 @@ func (s *IntegrationTestSuite) runValidators(c *chain, portOffset int) {
 		s.T().Logf("started AtomOne %s validator container: %s", c.id, resource.Container.ID)
 	}
 
-	rpcClient, err := rpchttp.New("tcp://localhost:26657", "/websocket")
-	s.Require().NoError(err)
-
+	rpcClient := s.rpcClient(s.chainA, 0)
 	nodeReadyTimeout := time.Minute
 	if runInCI {
 		nodeReadyTimeout = 5 * time.Minute

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -143,8 +143,6 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.initGenesis(s.chainA, vestingMnemonic, jailedValMnemonic)
 	s.initValidatorConfigs(s.chainA)
 	s.runValidators(s.chainA, 0)
-
-	time.Sleep(10 * time.Second)
 }
 
 func (s *IntegrationTestSuite) TearDownSuite() {

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -64,7 +64,7 @@ const (
 	proposalBypassMsgFilename      = "proposal_bypass_msg.json"
 	proposalMaxTotalBypassFilename = "proposal_max_total_bypass.json"
 	proposalCommunitySpendFilename = "proposal_community_spend.json"
-	proposalLSMParamUpdateFilename = "proposal_lsm_param_update.json"
+	proposalParamChangeFilename    = "param_change.json"
 
 	// hermesBinary              = "hermes"
 	// hermesConfigWithGasPrices = "/root/.hermes/config.toml"

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -41,7 +41,6 @@ import (
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	govtypes "github.com/atomone-hub/atomone/x/gov/types"
 )
@@ -626,61 +625,6 @@ func (s *IntegrationTestSuite) writeGovCommunitySpendProposal(c *chain, amount s
 	`
 	propMsgBody := fmt.Sprintf(template, govModuleAddress, recipient, amount.Denom, amount.Amount.String())
 	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalCommunitySpendFilename), []byte(propMsgBody))
-	s.Require().NoError(err)
-}
-
-func (s *IntegrationTestSuite) writeGovLegProposal(c *chain, height int64, name string) {
-	prop := &upgradetypes.Plan{
-		Name:   name,
-		Height: height,
-		Info:   `{"binaries":{"os1/arch1":"url1","os2/arch2":"url2"}}`,
-	}
-
-	commSpendBody, err := json.MarshalIndent(prop, "", " ")
-	s.Require().NoError(err)
-
-	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalCommunitySpendFilename), commSpendBody)
-	s.Require().NoError(err)
-}
-
-func (s *IntegrationTestSuite) writeLiquidStakingParamsUpdateProposal(c *chain, oldParams stakingtypes.Params) { //nolint:unused
-	template := `
-	{
-		"messages": [
-		 {
-		  "@type": "/cosmos.staking.v1beta1.MsgUpdateParams",
-		  "authority": "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn",
-		  "params": {
-		   "unbonding_time": "%s",
-		   "max_validators": %d,
-		   "max_entries": %d,
-		   "historical_entries": %d,
-		   "bond_denom": "%s",
-		   "min_commission_rate": "%s",
-		   "validator_bond_factor": "%s",
-		   "global_liquid_staking_cap": "%s",
-		   "validator_liquid_staking_cap": "%s"
-		  }
-		 }
-		],
-		"metadata": "ipfs://CID",
-		"deposit": "100uatone",
-		"title": "Update LSM Params",
-		"summary": "e2e-test updating LSM staking params"
-	   }`
-	propMsgBody := fmt.Sprintf(template,
-		oldParams.UnbondingTime,
-		oldParams.MaxValidators,
-		oldParams.MaxEntries,
-		oldParams.HistoricalEntries,
-		oldParams.BondDenom,
-		oldParams.MinCommissionRate,
-		sdk.NewDec(250),           // validator bond factor
-		sdk.NewDecWithPrec(25, 2), // 25 global_liquid_staking_cap
-		sdk.NewDecWithPrec(50, 2), // 50 validator_liquid_staking_cap
-	)
-
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalLSMParamUpdateFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 

--- a/tests/e2e/e2e_slashing_test.go
+++ b/tests/e2e/e2e_slashing_test.go
@@ -3,7 +3,7 @@ package e2e
 const jailedValidatorKey = "jailed"
 
 func (s *IntegrationTestSuite) testSlashing(chainEndpoint string) {
-	s.Run("test unjail validator", func() {
+	s.Run("unjail validator", func() {
 		validators, err := queryValidators(chainEndpoint)
 		s.Require().NoError(err)
 

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -12,132 +12,134 @@ import (
 )
 
 func (s *IntegrationTestSuite) testStaking() {
-	chainEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
+	s.Run("staking", func() {
+		chainEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
 
-	validatorA := s.chainA.validators[0]
-	validatorB := s.chainA.validators[1]
-	validatorAAddr, _ := validatorA.keyInfo.GetAddress()
-	validatorBAddr, _ := validatorB.keyInfo.GetAddress()
+		validatorA := s.chainA.validators[0]
+		validatorB := s.chainA.validators[1]
+		validatorAAddr, _ := validatorA.keyInfo.GetAddress()
+		validatorBAddr, _ := validatorB.keyInfo.GetAddress()
 
-	validatorAddressA := sdk.ValAddress(validatorAAddr).String()
-	validatorAddressB := sdk.ValAddress(validatorBAddr).String()
+		validatorAddressA := sdk.ValAddress(validatorAAddr).String()
+		validatorAddressB := sdk.ValAddress(validatorBAddr).String()
 
-	delegatorAddress, _ := s.chainA.genesisAccounts[2].keyInfo.GetAddress()
+		delegatorAddress, _ := s.chainA.genesisAccounts[2].keyInfo.GetAddress()
 
-	fees := sdk.NewCoin(uatoneDenom, sdk.NewInt(1))
+		fees := sdk.NewCoin(uatoneDenom, sdk.NewInt(1))
 
-	existingDelegation := sdk.ZeroDec()
-	res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-	if err == nil {
-		existingDelegation = res.GetDelegationResponse().GetDelegation().GetShares()
-	}
+		existingDelegation := sdk.ZeroDec()
+		res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+		if err == nil {
+			existingDelegation = res.GetDelegationResponse().GetDelegation().GetShares()
+		}
 
-	delegationAmount := sdk.NewInt(500000000)
-	delegation := sdk.NewCoin(uatoneDenom, delegationAmount) // 500 atom
+		delegationAmount := sdk.NewInt(500000000)
+		delegation := sdk.NewCoin(uatoneDenom, delegationAmount) // 500 atom
 
-	// Alice delegate uatone to Validator A
-	s.execDelegate(s.chainA, 0, delegation.String(), validatorAddressA, delegatorAddress.String(), atomoneHomePath, fees.String())
+		// Alice delegate uatone to Validator A
+		s.execDelegate(s.chainA, 0, delegation.String(), validatorAddressA, delegatorAddress.String(), atomoneHomePath, fees.String())
 
-	// Validate delegation successful
-	s.Require().Eventually(
-		func() bool {
-			res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-			amt := res.GetDelegationResponse().GetDelegation().GetShares()
-			s.Require().NoError(err)
+		// Validate delegation successful
+		s.Require().Eventually(
+			func() bool {
+				res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+				amt := res.GetDelegationResponse().GetDelegation().GetShares()
+				s.Require().NoError(err)
 
-			return amt.Equal(existingDelegation.Add(sdk.NewDecFromInt(delegationAmount)))
-		},
-		20*time.Second,
-		5*time.Second,
-	)
+				return amt.Equal(existingDelegation.Add(sdk.NewDecFromInt(delegationAmount)))
+			},
+			20*time.Second,
+			5*time.Second,
+		)
 
-	redelegationAmount := delegationAmount.Quo(sdk.NewInt(2))
-	redelegation := sdk.NewCoin(uatoneDenom, redelegationAmount) // 250 atom
+		redelegationAmount := delegationAmount.Quo(sdk.NewInt(2))
+		redelegation := sdk.NewCoin(uatoneDenom, redelegationAmount) // 250 atom
 
-	// Alice re-delegate half of her uatone delegation from Validator A to Validator B
-	s.execRedelegate(s.chainA, 0, redelegation.String(), validatorAddressA, validatorAddressB, delegatorAddress.String(), atomoneHomePath, fees.String())
+		// Alice re-delegate half of her uatone delegation from Validator A to Validator B
+		s.execRedelegate(s.chainA, 0, redelegation.String(), validatorAddressA, validatorAddressB, delegatorAddress.String(), atomoneHomePath, fees.String())
 
-	// Validate re-delegation successful
-	s.Require().Eventually(
-		func() bool {
-			res, err := queryDelegation(chainEndpoint, validatorAddressB, delegatorAddress.String())
-			amt := res.GetDelegationResponse().GetDelegation().GetShares()
-			s.Require().NoError(err)
+		// Validate re-delegation successful
+		s.Require().Eventually(
+			func() bool {
+				res, err := queryDelegation(chainEndpoint, validatorAddressB, delegatorAddress.String())
+				amt := res.GetDelegationResponse().GetDelegation().GetShares()
+				s.Require().NoError(err)
 
-			return amt.Equal(sdk.NewDecFromInt(redelegationAmount))
-		},
-		20*time.Second,
-		5*time.Second,
-	)
+				return amt.Equal(sdk.NewDecFromInt(redelegationAmount))
+			},
+			20*time.Second,
+			5*time.Second,
+		)
 
-	var (
-		currDelegation       sdk.Coin
-		currDelegationAmount math.Int
-	)
+		var (
+			currDelegation       sdk.Coin
+			currDelegationAmount math.Int
+		)
 
-	// query alice's current delegation from validator A
-	s.Require().Eventually(
-		func() bool {
-			res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-			amt := res.GetDelegationResponse().GetDelegation().GetShares()
-			s.Require().NoError(err)
+		// query alice's current delegation from validator A
+		s.Require().Eventually(
+			func() bool {
+				res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+				amt := res.GetDelegationResponse().GetDelegation().GetShares()
+				s.Require().NoError(err)
 
-			currDelegationAmount = amt.TruncateInt()
-			currDelegation = sdk.NewCoin(uatoneDenom, currDelegationAmount)
+				currDelegationAmount = amt.TruncateInt()
+				currDelegation = sdk.NewCoin(uatoneDenom, currDelegationAmount)
 
-			return currDelegation.IsValid()
-		},
-		20*time.Second,
-		5*time.Second,
-	)
+				return currDelegation.IsValid()
+			},
+			20*time.Second,
+			5*time.Second,
+		)
 
-	// Alice unbonds all her uatone delegation from Validator A
-	s.execUnbondDelegation(s.chainA, 0, currDelegation.String(), validatorAddressA, delegatorAddress.String(), atomoneHomePath, fees.String())
+		// Alice unbonds all her uatone delegation from Validator A
+		s.execUnbondDelegation(s.chainA, 0, currDelegation.String(), validatorAddressA, delegatorAddress.String(), atomoneHomePath, fees.String())
 
-	var ubdDelegationEntry types.UnbondingDelegationEntry
+		var ubdDelegationEntry types.UnbondingDelegationEntry
 
-	// validate unbonding delegations
-	s.Require().Eventually(
-		func() bool {
-			res, err := queryUnbondingDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-			s.Require().NoError(err)
+		// validate unbonding delegations
+		s.Require().Eventually(
+			func() bool {
+				res, err := queryUnbondingDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+				s.Require().NoError(err)
 
-			s.Require().Len(res.GetUnbond().Entries, 1)
-			ubdDelegationEntry = res.GetUnbond().Entries[0]
+				s.Require().Len(res.GetUnbond().Entries, 1)
+				ubdDelegationEntry = res.GetUnbond().Entries[0]
 
-			return ubdDelegationEntry.Balance.Equal(currDelegationAmount)
-		},
-		20*time.Second,
-		5*time.Second,
-	)
+				return ubdDelegationEntry.Balance.Equal(currDelegationAmount)
+			},
+			20*time.Second,
+			5*time.Second,
+		)
 
-	// cancel the full amount of unbonding delegations from Validator A
-	s.execCancelUnbondingDelegation(
-		s.chainA,
-		0,
-		currDelegation.String(),
-		validatorAddressA,
-		strconv.Itoa(int(ubdDelegationEntry.CreationHeight)),
-		delegatorAddress.String(),
-		atomoneHomePath,
-		fees.String(),
-	)
+		// cancel the full amount of unbonding delegations from Validator A
+		s.execCancelUnbondingDelegation(
+			s.chainA,
+			0,
+			currDelegation.String(),
+			validatorAddressA,
+			strconv.Itoa(int(ubdDelegationEntry.CreationHeight)),
+			delegatorAddress.String(),
+			atomoneHomePath,
+			fees.String(),
+		)
 
-	// validate that unbonding delegation was successfully canceled
-	s.Require().Eventually(
-		func() bool {
-			resDel, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-			amt := resDel.GetDelegationResponse().GetDelegation().GetShares()
-			s.Require().NoError(err)
+		// validate that unbonding delegation was successfully canceled
+		s.Require().Eventually(
+			func() bool {
+				resDel, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+				amt := resDel.GetDelegationResponse().GetDelegation().GetShares()
+				s.Require().NoError(err)
 
-			// expect that no unbonding delegations are found for validator A
-			_, err = queryUnbondingDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-			s.Require().Error(err)
+				// expect that no unbonding delegations are found for validator A
+				_, err = queryUnbondingDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
+				s.Require().Error(err)
 
-			// expect to get the delegation back
-			return amt.Equal(sdk.NewDecFromInt(currDelegationAmount))
-		},
-		20*time.Second,
-		5*time.Second,
-	)
+				// expect to get the delegation back
+				return amt.Equal(sdk.NewDecFromInt(currDelegationAmount))
+			},
+			20*time.Second,
+			5*time.Second,
+		)
+	})
 }

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -49,7 +49,7 @@ func (s *IntegrationTestSuite) testStaking() {
 				return amt.Equal(existingDelegation.Add(sdk.NewDecFromInt(delegationAmount)))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		redelegationAmount := delegationAmount.Quo(sdk.NewInt(2))
@@ -68,7 +68,7 @@ func (s *IntegrationTestSuite) testStaking() {
 				return amt.Equal(sdk.NewDecFromInt(redelegationAmount))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		var (
@@ -89,7 +89,7 @@ func (s *IntegrationTestSuite) testStaking() {
 				return currDelegation.IsValid()
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		// Alice unbonds all her uatone delegation from Validator A
@@ -109,7 +109,7 @@ func (s *IntegrationTestSuite) testStaking() {
 				return ubdDelegationEntry.Balance.Equal(currDelegationAmount)
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		// cancel the full amount of unbonding delegations from Validator A
@@ -139,7 +139,7 @@ func (s *IntegrationTestSuite) testStaking() {
 				return amt.Equal(sdk.NewDecFromInt(currDelegationAmount))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 	})
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -40,7 +40,7 @@ func (s *IntegrationTestSuite) TestEvidence() {
 	if !runEvidenceTest {
 		s.T().Skip()
 	}
-	s.testEvidence()
+	s.testEvidenceQueries()
 }
 
 func (s *IntegrationTestSuite) TestFeeGrant() {
@@ -54,9 +54,9 @@ func (s *IntegrationTestSuite) TestGov() {
 	if !runGovTest {
 		s.T().Skip()
 	}
-	s.GovSoftwareUpgrade()
-	s.GovCancelSoftwareUpgrade()
-	s.GovCommunityPoolSpend()
+	s.testGovSoftwareUpgrade()
+	s.testGovCancelSoftwareUpgrade()
+	s.testGovCommunityPoolSpend()
 }
 
 func (s *IntegrationTestSuite) TestSlashing() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -57,6 +57,7 @@ func (s *IntegrationTestSuite) TestGov() {
 	s.testGovSoftwareUpgrade()
 	s.testGovCancelSoftwareUpgrade()
 	s.testGovCommunityPoolSpend()
+	s.testGovParamChange()
 }
 
 func (s *IntegrationTestSuite) TestSlashing() {

--- a/tests/e2e/e2e_vesting_test.go
+++ b/tests/e2e/e2e_vesting_test.go
@@ -72,7 +72,7 @@ func (s *IntegrationTestSuite) testDelayedVestingAccount(api string) {
 				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		waitTime := acc.EndTime - time.Now().Unix()
@@ -141,7 +141,7 @@ func (s *IntegrationTestSuite) testContinuousVestingAccount(api string) {
 				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		waitStartTime := acc.StartTime - time.Now().Unix()
@@ -280,7 +280,7 @@ func (s *IntegrationTestSuite) testPeriodicVestingAccount(api string) { //nolint
 				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
 			},
 			20*time.Second,
-			5*time.Second,
+			time.Second,
 		)
 
 		//	Transfer coins should succeed

--- a/tests/e2e/e2e_vesting_test.go
+++ b/tests/e2e/e2e_vesting_test.go
@@ -49,7 +49,7 @@ func (s *IntegrationTestSuite) testDelayedVestingAccount(api string) {
 	sender, _ := val.keyInfo.GetAddress()
 	valOpAddr := sdk.ValAddress(sender).String()
 
-	s.Run("test delayed vesting genesis account", func() {
+	s.Run("delayed vesting genesis account", func() {
 		acc, err := queryDelayedVestingAccount(api, vestingDelayedAcc.String())
 		s.Require().NoError(err)
 
@@ -109,7 +109,7 @@ func (s *IntegrationTestSuite) testDelayedVestingAccount(api string) {
 }
 
 func (s *IntegrationTestSuite) testContinuousVestingAccount(api string) {
-	s.Run("test continuous vesting genesis account", func() {
+	s.Run("continuous vesting genesis account", func() {
 		var (
 			valIdx               = 0
 			chain                = s.chainA

--- a/tests/e2e/http_util.go
+++ b/tests/e2e/http_util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -13,6 +14,10 @@ func httpGet(endpoint string) ([]byte, error) {
 }
 
 const maxAttempt = 5
+
+func isErrNotFound(err error) bool {
+	return err != nil && strings.HasSuffix(err.Error(), http.StatusText(http.StatusNotFound))
+}
 
 func httpGet_(endpoint string, attempt int) ([]byte, error) {
 	resp, err := http.Get(endpoint) //nolint:gosec // this is only used during tests
@@ -27,7 +32,7 @@ func httpGet_(endpoint string, attempt int) ([]byte, error) {
 		return httpGet_(endpoint, attempt+1)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server responsed status %s", resp.Status)
+		return nil, fmt.Errorf("server status %s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/tests/e2e/http_util.go
+++ b/tests/e2e/http_util.go
@@ -5,14 +5,30 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 func httpGet(endpoint string) ([]byte, error) {
+	return httpGet_(endpoint, 0)
+}
+
+const maxAttempt = 5
+
+func httpGet_(endpoint string, attempt int) ([]byte, error) {
 	resp, err := http.Get(endpoint) //nolint:gosec // this is only used during tests
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusServiceUnavailable && attempt < maxAttempt {
+		// node not avail, wait and retry
+		time.Sleep(time.Second)
+		return httpGet_(endpoint, attempt+1)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server responsed status %s", resp.Status)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/tests/e2e/http_util.go
+++ b/tests/e2e/http_util.go
@@ -17,7 +17,7 @@ const maxAttempt = 5
 func httpGet_(endpoint string, attempt int) ([]byte, error) {
 	resp, err := http.Get(endpoint) //nolint:gosec // this is only used during tests
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
+		return nil, fmt.Errorf("failed to execute HTTP request %s: %w", endpoint, err)
 	}
 	defer resp.Body.Close()
 

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -185,9 +185,10 @@ func (q Keeper) Params(c context.Context, req *v1.QueryParamsRequest) (*v1.Query
 		response.TallyParams = &tallyParams
 
 	default:
-		return nil, status.Errorf(codes.InvalidArgument,
-			"%s is not a valid parameter type", req.ParamsType)
-
+		if len(req.ParamsType) > 1 {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"%s is not a valid parameter type", req.ParamsType)
+		}
 	}
 	response.Params = &params
 

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -814,8 +814,11 @@ func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 			"empty request",
 			func() {
 				req = &v1.QueryParamsRequest{}
+				expRes = &v1.QueryParamsResponse{
+					Params: &params,
+				}
 			},
-			false,
+			true,
 		},
 		{
 			"deposit params request",
@@ -824,6 +827,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 				depositParams := v1.NewDepositParams(params.MinDeposit, params.MaxDepositPeriod)
 				expRes = &v1.QueryParamsResponse{
 					DepositParams: &depositParams,
+					Params:        &params,
 				}
 			},
 			true,
@@ -835,6 +839,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 				votingParams := v1.NewVotingParams(params.VotingPeriod)
 				expRes = &v1.QueryParamsResponse{
 					VotingParams: &votingParams,
+					Params:       &params,
 				}
 			},
 			true,
@@ -846,6 +851,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 				tallyParams := v1.NewTallyParams(params.Quorum, params.Threshold)
 				expRes = &v1.QueryParamsResponse{
 					TallyParams: &tallyParams,
+					Params:      &params,
 				}
 			},
 			true,
@@ -871,6 +877,7 @@ func (suite *KeeperTestSuite) TestGRPCQueryParams() {
 				suite.Require().Equal(expRes.GetDepositParams(), params.GetDepositParams())
 				suite.Require().Equal(expRes.GetVotingParams(), params.GetVotingParams())
 				suite.Require().Equal(expRes.GetTallyParams(), params.GetTallyParams())
+				suite.Require().Equal(expRes.Params, params.Params)
 			} else {
 				suite.Require().Error(err)
 				suite.Require().Nil(params)
@@ -902,8 +909,11 @@ func (suite *KeeperTestSuite) TestLegacyGRPCQueryParams() {
 			"empty request",
 			func() {
 				req = &v1beta1.QueryParamsRequest{}
+				expRes = &v1beta1.QueryParamsResponse{
+					TallyParams: defaultTallyParams,
+				}
 			},
-			false,
+			true,
 		},
 		{
 			"deposit params request",


### PR DESCRIPTION
The main benefit of this change is to print the node logs when no blocks are produced. For that, because the nodes are running in a docker container, the docker API logs is requested.

Also:
- call `t.Run()` appropriately: some calls were irrelevant, like when they are used to execute a command which is a part of a test case.
- rename test cases appropriately
- print a hint "is the docker image up-to-date?" when the node don't produce block, because most of the time it is the reason.
- increase speed by removing some sleeps and reducing the `Eventually` tick parameter
- improve http request error handling by checking the response status, and eventually retry if the status is "Service Unavailable"
- add test on gov param change
- update `/atomone.gov.v1.Params` query so it doesn't return an error if paramType is not provided (see 945497f)
