### PR TITLE
chore: make build-ledger, fix reproducible builds, reinforce go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/tendermint/tendermint | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - run: git fetch --force --tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "$GO_VERSION"
+          go-version: "${{ env.GO_VERSION }}"
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - name: Set Go version
-        run: echo "GO_VERSION=$(make required_go_version_full)" >> $GITHUB_ENV
+
+      - name: Set go version
+        run: echo "GO_VERSION=$(make print_required_go_version)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.20"
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/tendermint/tendermint | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,12 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
+      - name: Set Go version
+        run: echo "GO_VERSION=$(make required_go_version_full)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21.13"
+          go-version: $GO_VERSION
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.21.13"
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: $GO_VERSION
+          go-version: "$GO_VERSION"
 
       - name: Set Env
         run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
           fetch-depth: 0
       - run: git fetch --force --tags
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
 
       - name: Set Env
-        run: echo "TM_VERSION=$(go list -m github.com/tendermint/tendermint | sed 's:.* ::')" >> $GITHUB_ENV
+        run: echo "TM_VERSION=$(go list -m github.com/cometbft/cometbft | sed 's:.* ::')" >> $GITHUB_ENV
 
       - name: Release
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean --release-notes ./RELEASE_NOTES.md
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ snapshot:
   name_template: "{{ .Version }}-{{ .ShortCommit }}"
 
 changelog:
-  skip: false
+  disable: true
 
 git:
   # What should be used to sort tags when gathering the current and previous

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ export GO111MODULE = on
 export CGO_ENABLED = 0
 
 build-ledger: check_version go.sum $(BUILDDIR)/
-        @echo "WARNING: Ledger build involves enabling cgo, which disables the ability to have reproducible builds."
-        CGO_ENABLED=1 go build -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) -o $(BUILDDIR)/ ./...
+	@echo "WARNING: Ledger build involves enabling cgo, which disables the ability to have reproducible builds."
+	CGO_ENABLED=1 go build -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) -o $(BUILDDIR)/ ./...
 
 # process build tags
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ REQUIRE_GO_VERSION = 1.21
 export GO111MODULE = on
 export CGO_ENABLED = 0
 
+build-ledger: check_version go.sum $(BUILDDIR)/
+        @echo "WARNING: Ledger build involves enabling cgo, which disables the ability to have reproducible builds."
+        CGO_ENABLED=1 go build -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) -o $(BUILDDIR)/ ./...
+
 # process build tags
 
 build_tags = netgo

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TEST_DOCKER_REPO=cosmos/contrib-atomonetest
 
 GO_SYSTEM_VERSION = $(shell go version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1-2)
 REQUIRE_GO_VERSION = 1.21
+REQUIRE_GO_VERSION_FULL = 1.21.13
 
 export GO111MODULE = on
 export CGO_ENABLED = 0
@@ -100,6 +101,9 @@ include contrib/devtools/Makefile
 ###############################################################################
 ###                              Build                                      ###
 ###############################################################################
+
+required_go_version_full:
+	@echo $(REQUIRE_GO_VERSION_FULL)
 
 check_version:
 ifneq ($(GO_SYSTEM_VERSION), $(REQUIRE_GO_VERSION))

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ The following modifications have been made to the Cosmos Hub software to create 
 ## Reproducible builds
 
 An effort has been made to make it possible to build the exact same binary
-locally as the Github Release section. To do this, checkout to the expected
-version and then simply run `make build` (which will output the binary to the
-`build` directory) or `make install`. The resulted binary should have the same
-sha256 hash than the one from the Github Release section.
+locally as the Github Release section. To do this:
+- Checkout to the expected released version
+- Run `make build` (which will output the binary to the `build` directory) or
+`make install`. Note that a fixed version of the `go` binary is required,
+follow the command instructions to install this specific version if needed.
+- The resulted binary should have the same sha256 hash than the one from the
+Github Release section.
 
 ## Ledger support
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ The following modifications have been made to the Cosmos Hub software to create 
 5. Changed Bech32 prefixes to `atone` (see `cmd/atomoned/cmd/config.go`)
 6. Removed ability for validators to vote on proposals with delegations, they can only use their own stake
 
-## Reproducible builds (TODO)
+## Reproducible builds
 
 An effort has been made to make it possible to build the exact same binary
 locally as the Github Release section. To do this, checkout to the expected
 version and then simply run `make build` (which will output the binary to the
 `build` directory) or `make install`. The resulted binary should have the same
 sha256 hash than the one from the Github Release section.
+
+## Ledger support
+
+Run `make build-ledger` to have ledger support in `./build/atomoned` binary.
+Note that this will disable reproducible builds, as it introduces OS
+dependencies.


### PR DESCRIPTION
- add make build-ledger
- fix CI env set TM_VERSION
- reinforce go version to go1.21.13
  - build will exit if go version doesn't match exactly
  - print instruction to run with specific go version
  - add `make print_required_go_version` so CI can fetch the information