### PR TITLE
chore: bump go to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMG_TAG=latest
 
 # Compile the atomoned binary
-FROM golang:1.21-alpine AS atomoned-builder
+FROM golang:1.22-alpine AS atomoned-builder
 WORKDIR /src/app/
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,20 @@
-# Upgrade AtomOne
+# Upgrading AtomOne
 
 This guide provides instructions for upgrading to specific versions of AtomOne.
+
+## Go version bump
+
+AtomOne v2 build requires a more recent version of the Go compiler: 1.22.10. If
+you already have go installed but with an other version, you can install
+go1.22.10 with the following command:
+
+```sh
+$ go install golang.org/dl/go1.22.10@latest
+$ go1.22.10 download
+```
+
+Then you need to update some env variables to invoke the makefile commands of
+AtomOne. For example, to run `make build` :
+```
+$ GOROOT=$(go1.22.10 env GOROOT) PATH=$GOROOT/bin:$PATH make build
+```

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -2,7 +2,7 @@
 # > docker build -t atomone .
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.atomone:/root/.atomone atomone atomoned init
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.atomone:/root/.atomone atomone atomoned start
-FROM golang:1.21-alpine AS build-env
+FROM golang:1.22-alpine AS build-env
 
 # Set up dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3

--- a/contrib/devdeps/go.mod
+++ b/contrib/devdeps/go.mod
@@ -1,6 +1,6 @@
 module github.com/atomone-hub/atomone/contrib/devdeps
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golangci/golangci-lint v1.56.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atomone-hub/atomone
 
-go 1.21.13
+go 1.22.10
 
 require (
 	cosmossdk.io/api v0.3.1


### PR DESCRIPTION
Go is being  carefully upgraded in SDK chains because of issues with state sync between nodes (although there is no evidence of this as far as I have investigated).

This change upgrades Go from 1.21.13 to 1.22.10 (the latest 1.22 release). Go 1.22 is already being used in the Gaia mainnet and no problems of state sync have been reported.

Once merged, this will allow the upgrade of cometbft which will fix 2 vulnerabilities raised by govuln.

The Upgrading file has been lazily updated, knowing that the merge of #57 will bring more context.
