### PR TITLE
chore(x/gov): add module migration to initialize new params

### DIFF
--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -29,7 +29,7 @@ jobs:
           go-version-file: go.mod
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -50,7 +50,7 @@ jobs:
     needs: [build, install-runsim]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -72,7 +72,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sim-label.yml
+++ b/.github/workflows/sim-label.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -41,7 +41,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -65,7 +65,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -81,7 +81,7 @@ jobs:
         - uses: actions/setup-go@v5
         - name: Install runsim
           run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-        - uses: actions/cache@v4.0.0
+        - uses: actions/cache@v4
           with:
             path: ~/go/bin
             key: ${{ runner.os }}-go-runsim-binary
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/x/gov/keeper/migrations.go
+++ b/x/gov/keeper/migrations.go
@@ -1,7 +1,10 @@
 package keeper
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/atomone-hub/atomone/x/gov/exported"
+	v5 "github.com/atomone-hub/atomone/x/gov/migrations/v5"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -16,4 +19,9 @@ func NewMigrator(keeper *Keeper, legacySubspace exported.ParamSubspace) Migrator
 		keeper:         keeper,
 		legacySubspace: legacySubspace,
 	}
+}
+
+// Migrate4to5 migrates the store from version 4 to 5.
+func (m Migrator) Migrate4to5(ctx sdk.Context) error {
+	return v5.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc)
 }

--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -1,0 +1,31 @@
+package v5
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	govv1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+)
+
+var ParamsKey = []byte{0x30}
+
+// Addition of the dynamic-deposit parameters.
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
+	store := ctx.KVStore(storeKey)
+	paramsBz := store.Get(ParamsKey)
+
+	var params govv1.Params
+	cdc.MustUnmarshal(paramsBz, &params)
+
+	defaultParams := govv1.DefaultParams()
+	params.MinDepositThrottler = defaultParams.MinDepositThrottler
+	params.MinInitialDepositThrottler = defaultParams.MinInitialDepositThrottler
+
+	bz, err := cdc.Marshal(&params)
+	if err != nil {
+		return err
+	}
+	store.Set(ParamsKey, bz)
+	return nil
+}

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -1,0 +1,41 @@
+package v5_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+
+	"github.com/atomone-hub/atomone/x/gov"
+	v5 "github.com/atomone-hub/atomone/x/gov/migrations/v5"
+	govv1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+)
+
+func TestMigrateStore(t *testing.T) {
+	cdc := moduletestutil.MakeTestEncodingConfig(gov.AppModuleBasic{}, bank.AppModuleBasic{}).Codec
+	govKey := storetypes.NewKVStoreKey("gov")
+	ctx := testutil.DefaultContext(govKey, storetypes.NewTransientStoreKey("transient_test"))
+	store := ctx.KVStore(govKey)
+
+	var params govv1.Params
+	bz := store.Get(v5.ParamsKey)
+	require.NoError(t, cdc.Unmarshal(bz, &params))
+	require.NotNil(t, params)
+	require.Nil(t, params.MinDepositThrottler)
+	require.Nil(t, params.MinInitialDepositThrottler)
+
+	// Run migrations.
+	err := v5.MigrateStore(ctx, govKey, cdc)
+	require.NoError(t, err)
+
+	// Check params
+	bz = store.Get(v5.ParamsKey)
+	require.NoError(t, cdc.Unmarshal(bz, &params))
+	require.NotNil(t, params)
+	require.Equal(t, govv1.DefaultParams().MinDepositThrottler, params.MinDepositThrottler)
+	require.Equal(t, govv1.DefaultParams().MinInitialDepositThrottler, params.MinInitialDepositThrottler)
+}

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -39,7 +39,7 @@ import (
 	"github.com/atomone-hub/atomone/x/gov/types/v1beta1"
 )
 
-const ConsensusVersion = 4
+const ConsensusVersion = 5
 
 var (
 	_ module.EndBlockAppModule   = AppModule{}
@@ -284,7 +284,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	v1.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 
 	m := keeper.NewMigrator(am.keeper, am.legacySubspace)
-	_ = m
+	if err := cfg.RegisterMigration(govtypes.ModuleName, 4, m.Migrate4to5); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/gov from version 4 to version 5: %v", err))
+	}
 }
 
 // InitGenesis performs genesis initialization for the gov module. It returns


### PR DESCRIPTION
I had to change the CI `action/cache` version because the version was deprecated.