### PR TITLE
feat(x/feemarket): sync with `skip/feemarket` `v1.1.1` (except tests) and re-add postHandler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,6 +52,7 @@ import (
 	"github.com/atomone-hub/atomone/app/params"
 	"github.com/atomone-hub/atomone/app/upgrades"
 	v2 "github.com/atomone-hub/atomone/app/upgrades/v2"
+	atomonepost "github.com/atomone-hub/atomone/post"
 	govtypes "github.com/atomone-hub/atomone/x/gov/types"
 )
 
@@ -232,7 +233,16 @@ func NewAtomOneApp(
 		panic(fmt.Errorf("failed to create AnteHandler: %s", err))
 	}
 
+	postHandlerOptions := atomonepost.HandlerOptions{
+		FeemarketKeeper: app.FeemarketKeeper,
+	}
+	postHandler, err := atomonepost.NewPostHandler(postHandlerOptions)
+	if err != nil {
+		panic(err)
+	}
+
 	app.SetAnteHandler(anteHandler)
+	app.SetPostHandler(postHandler)
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)

--- a/post/post.go
+++ b/post/post.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	feemarketpost "github.com/atomone-hub/atomone/x/feemarket/post"
+)
+
+// PostHandlerOptions are the options required for constructing a FeeMarket PostHandler.
+type HandlerOptions struct {
+	FeemarketKeeper feemarketpost.FeemarketKeeper
+}
+
+// NewPostHandler returns a PostHandler chain with the fee deduct decorator.
+func NewPostHandler(options HandlerOptions) (sdk.PostHandler, error) {
+	if options.FeemarketKeeper == nil {
+		return nil, errorsmod.Wrap(sdkerrors.ErrLogic, "feemarket keeper is required for post builder")
+	}
+
+	postDecorators := []sdk.PostDecorator{
+		feemarketpost.NewFeemarketStateUpdateDecorator(
+			options.FeemarketKeeper,
+		),
+	}
+
+	return sdk.ChainPostDecorators(postDecorators...), nil
+}

--- a/x/feemarket/post/expected_keeper.go
+++ b/x/feemarket/post/expected_keeper.go
@@ -1,0 +1,17 @@
+package post
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	feemarkettypes "github.com/atomone-hub/atomone/x/feemarket/types"
+)
+
+// FeeMarketKeeper defines the expected feemarket keeper.
+//
+//go:generate mockery --name FeeMarketKeeper --filename mock_feemarket_keeper.go
+type FeemarketKeeper interface {
+	GetState(ctx sdk.Context) (feemarkettypes.State, error)
+	GetParams(ctx sdk.Context) (feemarkettypes.Params, error)
+	SetState(ctx sdk.Context, state feemarkettypes.State) error
+	GetEnabledHeight(ctx sdk.Context) (int64, error)
+}

--- a/x/feemarket/post/update_state.go
+++ b/x/feemarket/post/update_state.go
@@ -1,0 +1,74 @@
+package post
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// FeemarketStateUpdateDecorator updates the state of the fee market based on the gas consumed in the gasmeter.
+// Call next PostHandler if fees successfully deducted.
+// CONTRACT: Tx must implement FeeTx interface
+type FeemarketStateUpdateDecorator struct {
+	feemarketKeeper FeemarketKeeper
+}
+
+func NewFeemarketStateUpdateDecorator(fmk FeemarketKeeper) FeemarketStateUpdateDecorator {
+	return FeemarketStateUpdateDecorator{
+		feemarketKeeper: fmk,
+	}
+}
+
+// PostHandle deducts the fee from the fee payer based on the min base fee and the gas consumed in the gasmeter.
+// If there is a difference between the provided fee and the min-base fee, the difference is paid as a tip.
+// Fees are sent to the x/feemarket fee-collector address.
+func (dfd FeemarketStateUpdateDecorator) PostHandle(ctx sdk.Context, tx sdk.Tx, simulate, success bool, next sdk.PostHandler) (sdk.Context, error) {
+	// GenTx consume no fee
+	if ctx.BlockHeight() == 0 {
+		return next(ctx, tx, simulate, success)
+	}
+
+	// update fee market params
+	params, err := dfd.feemarketKeeper.GetParams(ctx)
+	if err != nil {
+		return ctx, errorsmod.Wrapf(err, "unable to get fee market params")
+	}
+
+	// return if disabled
+	if !params.Enabled {
+		return next(ctx, tx, simulate, success)
+	}
+
+	enabledHeight, err := dfd.feemarketKeeper.GetEnabledHeight(ctx)
+	if err != nil {
+		return ctx, errorsmod.Wrapf(err, "unable to get fee market enabled height")
+	}
+
+	// if the current height is that which enabled the feemarket or lower, skip deduction
+	if ctx.BlockHeight() <= enabledHeight {
+		return next(ctx, tx, simulate, success)
+	}
+
+	// update fee market state
+	state, err := dfd.feemarketKeeper.GetState(ctx)
+	if err != nil {
+		return ctx, errorsmod.Wrapf(err, "unable to get fee market state")
+	}
+
+	gas := ctx.GasMeter().GasConsumed() // use context gas consumed
+
+	ctx.Logger().Info("feemarket post handle",
+		"gas consumed", gas,
+	)
+
+	err = state.Update(gas, params)
+	if err != nil {
+		return ctx, errorsmod.Wrapf(err, "unable to update fee market state")
+	}
+
+	err = dfd.feemarketKeeper.SetState(ctx, state)
+	if err != nil {
+		return ctx, errorsmod.Wrapf(err, "unable to set fee market state")
+	}
+
+	return next(ctx, tx, simulate, success)
+}

--- a/x/feemarket/types/state.go
+++ b/x/feemarket/types/state.go
@@ -156,7 +156,7 @@ func (s *State) GetAverageUtilization(params Params) math.LegacyDec {
 
 // ValidateBasic performs basic validation on the state.
 func (s *State) ValidateBasic() error {
-	if s.Window == nil || len(s.Window) == 0 {
+	if s.Window == nil {
 		return fmt.Errorf("block utilization window cannot be nil or empty")
 	}
 


### PR DESCRIPTION
as the title suggests.

change to 0 fees in simulation to allow for no bank balances in sim, as per https://github.com/skip-mev/feemarket/pull/138
I also re-added the postHandler since wrongly removed also the logic to updated consumed gas in the module state

missing backporting tests from https://github.com/skip-mev/feemarket/pull/138