### PR TITLE
chore: bump `actions/cache` in github actions

### DIFF
--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -29,7 +29,7 @@ jobs:
           go-version-file: go.mod
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -50,7 +50,7 @@ jobs:
     needs: [build, install-runsim]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -72,7 +72,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sim-label.yml
+++ b/.github/workflows/sim-label.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -41,7 +41,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -65,7 +65,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -81,7 +81,7 @@ jobs:
         - uses: actions/setup-go@v5
         - name: Install runsim
           run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-        - uses: actions/cache@v4.0.0
+        - uses: actions/cache@v4
           with:
             path: ~/go/bin
             key: ${{ runner.os }}-go-runsim-binary
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
bump dependency to fix github actions errors