### PR TITLE
chore: bump `actions/cache` in github actions for `release/v1.x` branch

### DIFF
--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: 1.21.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -50,7 +50,7 @@ jobs:
     needs: [build, install-runsim]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -72,7 +72,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sim-label.yml
+++ b/.github/workflows/sim-label.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.21.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.21.x
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -43,7 +43,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -67,7 +67,7 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -85,7 +85,7 @@ jobs:
             go-version: 1.21.x
         - name: Install runsim
           run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-        - uses: actions/cache@v4.0.0
+        - uses: actions/cache@v4
           with:
             path: ~/go/bin
             key: ${{ runner.os }}-go-runsim-binary
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary
@@ -109,7 +109,7 @@ jobs:
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-runsim-binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-      - uses: actions/cache@v4.0.0
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build


### PR DESCRIPTION
Same as #94 but targeting the `release/v1.x` branch