### PR TITLE
deps: upgrade ibc-go to v7.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 
 ### STATE BREAKING
 
+## v1.1.2
+
+*Mar 12th, 2025*
+
+### DEPENDENCIES
+
+- Upgrade ibc-go to v7.10.0 to fix ISA-2025-001 [#97](https://github.com/atomone-hub/atomone/pull/97)
+
+
 ## v1.1.1
 
 *Feb 28th, 2025*

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.47.13
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.7.0
-	github.com/cosmos/ibc-go/v7 v7.9.2
+	github.com/cosmos/ibc-go/v7 v7.10.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/gofuzz v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fr
 github.com/cosmos/gogoproto v1.7.0/go.mod h1:yWChEv5IUEYURQasfyBW5ffkMHR/90hiHgbNgrtp4j0=
 github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
 github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
-github.com/cosmos/ibc-go/v7 v7.9.2 h1:TReF8shQmjvIMXvSJ8AvRgpnf7g6BEeHx8l1rIqQlgU=
-github.com/cosmos/ibc-go/v7 v7.9.2/go.mod h1:v2hOSSf9Lmx2S590X/3aJ8CvHj4ewZV3Bviu6by2Y3g=
+github.com/cosmos/ibc-go/v7 v7.10.0 h1:/IUJ6wilNnGcpP5XMb7p74JnctKDrFSv30i7aoJRnVI=
+github.com/cosmos/ibc-go/v7 v7.10.0/go.mod h1:PiVSJhIPBq/rI+6UOfKPy4RKDCvQ2vR+Vdb6SaowETQ=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=


### PR DESCRIPTION
Upgrade ibc-go to v7.10.0 to fix [ISA-2025-001](https://github.com/cosmos/ibc-go/security/advisories/GHSA-4wf3-5qj9-368v)