### PR TITLE
fix(x/gov): proposal v1 to v1beta1 converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fix vuln GO-2024-3112 and GO-2024-2951 [#62](https://github.com/atomone-hub/atomone/pull/62)
 - Fix vuln GHSA-8wcc-m6j2-qxvm [#67](https://github.com/atomone-hub/atomone/pull/67)
 - (x/gov): Fix proposal converter from v1 to v1beta1 when proposal has not
-  messages [#xx](https://github.com/atomone-hub/atomone/pull/xx)
+  messages [#102](https://github.com/atomone-hub/atomone/pull/102)
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Fix vuln GO-2024-3279 [#60](https://github.com/atomone-hub/atomone/pull/60)
 - Fix vuln GO-2024-3112 and GO-2024-2951 [#62](https://github.com/atomone-hub/atomone/pull/62)
 - Fix vuln GHSA-8wcc-m6j2-qxvm [#67](https://github.com/atomone-hub/atomone/pull/67)
+- (x/gov): Fix proposal converter from v1 to v1beta1 when proposal has not
+  messages [#xx](https://github.com/atomone-hub/atomone/pull/xx)
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fix vuln GO-2024-3279 [#60](https://github.com/atomone-hub/atomone/pull/60)
 - Fix vuln GO-2024-3112 and GO-2024-2951 [#62](https://github.com/atomone-hub/atomone/pull/62)
 - Fix vuln GHSA-8wcc-m6j2-qxvm [#67](https://github.com/atomone-hub/atomone/pull/67)
-- (x/gov): Fix proposal converter from v1 to v1beta1 when proposal has not
+- (x/gov): Fix proposal converter from v1 to v1beta1 when proposal has no
   messages [#102](https://github.com/atomone-hub/atomone/pull/102)
 
 ### FEATURES

--- a/x/gov/migrations/v3/convert.go
+++ b/x/gov/migrations/v3/convert.go
@@ -3,6 +3,8 @@ package v3
 import (
 	"fmt"
 
+	"github.com/golang/protobuf/proto"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -48,8 +50,18 @@ func ConvertToLegacyProposal(proposal v1.Proposal) (v1beta1.Proposal, error) {
 	if err != nil {
 		return v1beta1.Proposal{}, err
 	}
-	if len(msgs) != 1 {
-		return v1beta1.Proposal{}, sdkerrors.ErrInvalidType.Wrap("can't convert a gov/v1 Proposal to gov/v1beta1 Proposal when amount of proposal messages not exactly one")
+	if len(msgs) == 0 {
+		// If there is no messages, consider proposal as a text proposal
+		content := v1beta1.NewTextProposal(proposal.Title, proposal.Summary)
+		msg, ok := content.(proto.Message)
+		if !ok {
+			return v1beta1.Proposal{}, sdkerrors.ErrInvalidType.Wrap("can't convert a gov/v1 Proposal to gov/v1beta1 Proposal: content is not a proto message")
+		}
+		legacyProposal.Content, err = codectypes.NewAnyWithValue(msg)
+		return legacyProposal, err
+	}
+	if len(msgs) > 1 {
+		return v1beta1.Proposal{}, sdkerrors.ErrInvalidType.Wrap("can't convert a gov/v1 Proposal to gov/v1beta1 Proposal when amount of proposal messages exceeds one")
 	}
 	if legacyMsg, ok := msgs[0].(*v1.MsgExecLegacyContent); ok {
 		// check that the content struct can be unmarshalled


### PR DESCRIPTION
Converter was returning an error when the v1 proposal has no messages, which can be considered as a bug since the v1 API allows to submit proposals without messages.

The fix handles such proposal and turn them into v1beta1 text proposal.

Additionnaly to unit tests, a test was made with a local node, ensuring it is now possible to request a v1 proposal that has no messages using a v1beta1 request.