### PR TITLE
feat(x/gov): change lazy dynamic deposit computation in favor of endblocker per-tick update

### DIFF
--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -217,6 +217,9 @@ func EndBlocker(ctx sdk.Context, keeper *keeper.Keeper) {
 		)
 		return false
 	})
+
+	keeper.UpdateMinInitialDeposit(ctx, true)
+	keeper.UpdateMinDeposit(ctx, true)
 }
 
 // executes handle(msg) and recovers from panic.

--- a/x/gov/keeper/min_deposit.go
+++ b/x/gov/keeper/min_deposit.go
@@ -34,8 +34,7 @@ func (keeper Keeper) IncrementActiveProposalsNumber(ctx sdk.Context) {
 	activeProposalsNumber := keeper.GetActiveProposalsNumber(ctx) + 1
 	keeper.SetActiveProposalsNumber(ctx, activeProposalsNumber)
 
-	currMinDeposit := keeper.GetMinDeposit(ctx)
-	keeper.SetLastMinDeposit(ctx, currMinDeposit, ctx.BlockTime())
+	keeper.UpdateMinDeposit(ctx, false)
 }
 
 // DecrementActiveProposalsNumber decrements the number of active proposals by one
@@ -48,8 +47,7 @@ func (keeper Keeper) DecrementActiveProposalsNumber(ctx sdk.Context) {
 		panic("number of active proposals should never be negative")
 	}
 
-	currMinDeposit := keeper.GetMinDeposit(ctx)
-	keeper.SetLastMinDeposit(ctx, currMinDeposit, ctx.BlockTime())
+	keeper.UpdateMinDeposit(ctx, false)
 }
 
 // SetLastMinDeposit updates the last min deposit and last min deposit time.
@@ -78,18 +76,33 @@ func (keeper Keeper) GetLastMinDeposit(ctx sdk.Context) (sdk.Coins, time.Time) {
 
 // GetMinDeposit returns the (dynamic) minimum deposit currently required for a proposal
 func (keeper Keeper) GetMinDeposit(ctx sdk.Context) sdk.Coins {
+	minDeposit, _ := keeper.GetLastMinDeposit(ctx)
+
+	if minDeposit.Empty() {
+		// ValidateBasic prevents an empty FloorValue
+		// (and thus an empty deposit), if LastMinDeposit is empty
+		// it means it was never set, so we return the floor value
+		return keeper.GetParams(ctx).MinDepositThrottler.GetFloorValue()
+	}
+
+	return minDeposit
+}
+
+// UpdateMinDeposit updates the minimum deposit required for a proposal
+func (keeper Keeper) UpdateMinDeposit(ctx sdk.Context, checkElapsedTime bool) {
 	params := keeper.GetParams(ctx)
-	minDepositFloor := sdk.Coins(params.MinDepositThrottler.FloorValue)
 	tick := params.MinDepositThrottler.UpdatePeriod
+	lastMinDeposit, lastMinDepositTime := keeper.GetLastMinDeposit(ctx)
+	if checkElapsedTime && ctx.BlockTime().Sub(lastMinDepositTime).Nanoseconds() < tick.Nanoseconds() {
+		return
+	}
+
+	minDepositFloor := sdk.Coins(params.MinDepositThrottler.FloorValue)
 	targetActiveProposals := math.NewIntFromUint64(params.MinDepositThrottler.TargetActiveProposals)
 	k := params.MinDepositThrottler.SensitivityTargetDistance
 	var a sdk.Dec
 
 	numActiveProposals := math.NewIntFromUint64(keeper.GetActiveProposalsNumber(ctx))
-	lastMinDeposit, lastMinDepositTime := keeper.GetLastMinDeposit(ctx)
-	// get number of ticks passed since last update
-	ticksPassed := ctx.BlockTime().Sub(lastMinDepositTime).Nanoseconds() / tick.Nanoseconds()
-
 	if numActiveProposals.GT(targetActiveProposals) {
 		a = sdk.MustNewDecFromStr(params.MinDepositThrottler.IncreaseRatio)
 	} else {
@@ -107,26 +120,24 @@ func (keeper Keeper) GetMinDeposit(ctx sdk.Context) sdk.Coins {
 		c := a.Mul(b)
 		percChange = percChange.Add(c)
 	}
-	if ticksPassed != 0 {
-		percChange = percChange.Power(uint64(ticksPassed))
-	}
 
-	minDeposit := sdk.Coins{}
+	newMinDeposit := sdk.Coins{}
 	minDepositFloorDenomsSeen := make(map[string]bool)
 	for _, lastMinDepositCoin := range lastMinDeposit {
 		minDepositFloorCoinAmt := minDepositFloor.AmountOf(lastMinDepositCoin.Denom)
 		if minDepositFloorCoinAmt.IsZero() {
-			// minDepositFloor was changed and this coin was removed,
-			// reflect this also in the current min deposit, i.e. remove
-			// this coin
+			// minDepositFloor was changed since last update,
+			// and this coin was removed.
+			// reflect this also in the current min initial deposit,
+			// i.e. remove this coin
 			continue
 		}
 		minDepositFloorDenomsSeen[lastMinDepositCoin.Denom] = true
 		minDepositCoinAmt := lastMinDepositCoin.Amount.ToLegacyDec().Mul(percChange).TruncateInt()
 		if minDepositCoinAmt.LT(minDepositFloorCoinAmt) {
-			minDeposit = append(minDeposit, sdk.NewCoin(lastMinDepositCoin.Denom, minDepositFloorCoinAmt))
+			newMinDeposit = append(newMinDeposit, sdk.NewCoin(lastMinDepositCoin.Denom, minDepositFloorCoinAmt))
 		} else {
-			minDeposit = append(minDeposit, sdk.NewCoin(lastMinDepositCoin.Denom, minDepositCoinAmt))
+			newMinDeposit = append(newMinDeposit, sdk.NewCoin(lastMinDepositCoin.Denom, minDepositCoinAmt))
 		}
 	}
 
@@ -135,12 +146,12 @@ func (keeper Keeper) GetMinDeposit(ctx sdk.Context) sdk.Coins {
 		if _, seen := minDepositFloorDenomsSeen[minDepositFloorCoin.Denom]; !seen {
 			minDepositCoinAmt := minDepositFloorCoin.Amount.ToLegacyDec().Mul(percChange).TruncateInt()
 			if minDepositCoinAmt.LT(minDepositFloorCoin.Amount) {
-				minDeposit = append(minDeposit, minDepositFloorCoin)
+				newMinDeposit = append(newMinDeposit, minDepositFloorCoin)
 			} else {
-				minDeposit = append(minDeposit, sdk.NewCoin(minDepositFloorCoin.Denom, minDepositCoinAmt))
+				newMinDeposit = append(newMinDeposit, sdk.NewCoin(minDepositFloorCoin.Denom, minDepositCoinAmt))
 			}
 		}
 	}
 
-	return minDeposit
+	keeper.SetLastMinDeposit(ctx, newMinDeposit, ctx.BlockTime())
 }

--- a/x/gov/keeper/min_deposit_test.go
+++ b/x/gov/keeper/min_deposit_test.go
@@ -56,6 +56,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, 0)
 				k.SetLastMinDeposit(ctx, minDepositFloor, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: minDepositFloor.String(),
 		},
@@ -64,6 +65,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N)
 				k.SetLastMinDeposit(ctx, minDepositFloor, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: minDepositFloor.String(),
 		},
@@ -72,6 +74,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N+1)
 				k.SetLastMinDeposit(ctx, minDepositFloor, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: "10500000stake",
 		},
@@ -84,6 +87,7 @@ func TestGetMinDeposit(t *testing.T) {
 				),
 					minDepositTimeFromTicks(0),
 				)
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: "10500000stake",
 		},
@@ -92,6 +96,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N-1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: "19500000stake",
 		},
@@ -100,6 +105,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: minDepositFloorX2.String(),
 		},
@@ -108,6 +114,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N+1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(0))
+				k.UpdateMinDeposit(ctx, false)
 			},
 			expectedMinDeposit: "21000000stake",
 		},
@@ -116,6 +123,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N-1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(1))
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: "19500000stake",
 		},
@@ -124,6 +132,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(1))
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: minDepositFloorX2.String(),
 		},
@@ -132,6 +141,7 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N+1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(1))
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: "21000000stake",
 		},
@@ -140,6 +150,8 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N-1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(2))
+				k.UpdateMinDeposit(ctx.WithBlockTime(minDepositTimeFromTicks(1)), true)
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: "19012500stake",
 		},
@@ -148,6 +160,8 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(2))
+				k.UpdateMinDeposit(ctx.WithBlockTime(minDepositTimeFromTicks(1)), true)
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: minDepositFloorX2.String(),
 		},
@@ -156,6 +170,8 @@ func TestGetMinDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetActiveProposalsNumber(ctx, N+1)
 				k.SetLastMinDeposit(ctx, minDepositFloorX2, minDepositTimeFromTicks(2))
+				k.UpdateMinDeposit(ctx.WithBlockTime(minDepositTimeFromTicks(1)), true)
+				k.UpdateMinDeposit(ctx, true)
 			},
 			expectedMinDeposit: "22050000stake",
 		},

--- a/x/gov/keeper/min_initial_deposit_test.go
+++ b/x/gov/keeper/min_initial_deposit_test.go
@@ -54,6 +54,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, 0)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloor, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: minInitialDepositFloor.String(),
 		},
@@ -62,6 +63,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloor, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: minInitialDepositFloor.String(),
 		},
@@ -70,6 +72,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N+1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloor, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: "101000stake",
 		},
@@ -82,6 +85,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 				),
 					minInitialDepositTimeFromTicks(0),
 				)
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: "101000stake",
 		},
@@ -90,6 +94,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N-1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: "199000stake",
 		},
@@ -98,6 +103,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: minInitialDepositFloorX2.String(),
 		},
@@ -106,6 +112,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N+1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(0))
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: "202000stake",
 		},
@@ -114,6 +121,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N-1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(1))
+				k.UpdateMinInitialDeposit(ctx, true)
 			},
 			expectedMinInitialDeposit: "199000stake",
 		},
@@ -122,6 +130,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(1))
+				k.UpdateMinInitialDeposit(ctx, true)
 			},
 			expectedMinInitialDeposit: minInitialDepositFloorX2.String(),
 		},
@@ -130,6 +139,7 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N+1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(1))
+				k.UpdateMinInitialDeposit(ctx, true)
 			},
 			expectedMinInitialDeposit: "202000stake",
 		},
@@ -138,6 +148,8 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N-1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(2))
+				k.UpdateMinInitialDeposit(ctx.WithBlockTime(minInitialDepositTimeFromTicks(1)), true)
+				k.UpdateMinInitialDeposit(ctx, true)
 			},
 			expectedMinInitialDeposit: "198005stake",
 		},
@@ -146,6 +158,8 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(2))
+				k.UpdateMinInitialDeposit(ctx.WithBlockTime(minInitialDepositTimeFromTicks(1)), true)
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: minInitialDepositFloorX2.String(),
 		},
@@ -154,6 +168,8 @@ func TestGetMinInitialDeposit(t *testing.T) {
 			setup: func(ctx sdk.Context, k *keeper.Keeper) {
 				k.SetInactiveProposalsNumber(ctx, N+1)
 				k.SetLastMinInitialDeposit(ctx, minInitialDepositFloorX2, minInitialDepositTimeFromTicks(2))
+				k.UpdateMinInitialDeposit(ctx.WithBlockTime(minInitialDepositTimeFromTicks(1)), true)
+				k.UpdateMinInitialDeposit(ctx, false)
 			},
 			expectedMinInitialDeposit: "204020stake",
 		},


### PR DESCRIPTION
As per the title, it seems unnecessarily complex in hindsight to lazily compute the dynamic deposit.
If we assume per-tick updates aren't too frequent, it's better to do this then only once and limit to reading a single value for queries.
Moreover, since store updates just overwrite an existing value, even a per-block update should not be too expensive in practice.