### PR TITLE
test(x/gov): independent cases in KeeperTestSuite

### DIFF
--- a/x/gov/keeper/keeper_test.go
+++ b/x/gov/keeper/keeper_test.go
@@ -39,6 +39,10 @@ func (suite *KeeperTestSuite) SetupSuite() {
 	suite.reset()
 }
 
+func (suite *KeeperTestSuite) SetupSubTest() {
+	suite.reset()
+}
+
 func (suite *KeeperTestSuite) reset() {
 	govKeeper, mocks, encCfg, ctx := setupGovKeeper(suite.T())
 	acctKeeper, bankKeeper, stakingKeeper := mocks.acctKeeper, mocks.bankKeeper, mocks.stakingKeeper

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -123,9 +123,9 @@ func (suite *KeeperTestSuite) TestSubmitProposalReq() {
 		suite.Run(name, func() {
 			msg, err := tc.preRun()
 			suite.Require().NoError(err)
+
 			res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
-			// reset proposal number, we ignore the dynamic deposit system in these tests
-			suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 				suite.Require().Contains(err.Error(), tc.expErrMsg)
@@ -161,14 +161,6 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 	)
 	suite.Require().NoError(err)
 
-	res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res.ProposalId)
-	proposalId := res.ProposalId
-
-	// reset proposal number, we ignore the dynamic deposit system in these tests
-	suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 	cases := map[string]struct {
 		preRun    func() uint64
 		expErr    bool
@@ -181,7 +173,7 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					coins,
+					v1.DefaultMinInitialDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -192,10 +184,6 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:    v1.VoteOption_VOTE_OPTION_YES,
@@ -206,7 +194,10 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 		},
 		"metadata too long": {
 			preRun: func() uint64 {
-				return proposalId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			option:    v1.VoteOption_VOTE_OPTION_YES,
 			voter:     proposer,
@@ -216,7 +207,10 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 		},
 		"voter error": {
 			preRun: func() uint64 {
-				return proposalId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			option:    v1.VoteOption_VOTE_OPTION_YES,
 			voter:     sdk.AccAddress(strings.Repeat("a", 300)),
@@ -239,10 +233,6 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:   v1.VoteOption_VOTE_OPTION_YES,
@@ -274,7 +264,6 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 	proposer := addrs[0]
 
 	coins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100000)))
-	minDeposit := suite.govKeeper.GetMinDeposit(suite.ctx)
 	bankMsg := &banktypes.MsgSend{
 		FromAddress: govAcct.String(),
 		ToAddress:   proposer.String(),
@@ -283,21 +272,13 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		minDeposit,
+		v1.DefaultMinDepositFloor,
 		proposer.String(),
 		"",
 		"Proposal",
 		"description of proposal",
 	)
 	suite.Require().NoError(err)
-
-	res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res.ProposalId)
-	proposalId := res.ProposalId
-
-	// reset proposal number, we ignore the dynamic deposit system in these tests
-	suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
 
 	cases := map[string]struct {
 		preRun    func() uint64
@@ -312,7 +293,7 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					coins,
+					v1.DefaultMinInitialDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -323,9 +304,6 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
 
 				return res.ProposalId
 			},
@@ -337,7 +315,10 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 		},
 		"metadata too long": {
 			preRun: func() uint64 {
-				return proposalId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			option:    v1.VoteOption_VOTE_OPTION_YES,
 			voter:     proposer,
@@ -347,7 +328,10 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 		},
 		"voter error": {
 			preRun: func() uint64 {
-				return proposalId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			option:    v1.VoteOption_VOTE_OPTION_YES,
 			voter:     sdk.AccAddress(strings.Repeat("a", 300)),
@@ -359,7 +343,7 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					minDeposit,
+					v1.DefaultMinDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -370,10 +354,6 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:   v1.VoteOption_VOTE_OPTION_YES,
@@ -404,7 +384,6 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 	proposer := addrs[0]
 
 	coins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100000)))
-	minDeposit := sdk.Coins(suite.govKeeper.GetMinDeposit(suite.ctx))
 	bankMsg := &banktypes.MsgSend{
 		FromAddress: govAcct.String(),
 		ToAddress:   proposer.String(),
@@ -413,18 +392,13 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		coins,
+		v1.DefaultMinInitialDepositFloor,
 		proposer.String(),
 		"",
 		"Proposal",
 		"description of proposal",
 	)
 	suite.Require().NoError(err)
-
-	res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res.ProposalId)
-	pId := res.ProposalId
 
 	cases := map[string]struct {
 		preRun     func() uint64
@@ -445,20 +419,27 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 		},
 		"all good": {
 			preRun: func() uint64 {
-				return pId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   minDeposit,
+			deposit:   v1.DefaultMinDepositFloor,
 			expErr:    false,
 			options:   v1.NewNonSplitVoteOption(v1.OptionYes),
 		},
 		"invalid deposited coin ": {
 			preRun: func() uint64 {
-				return pId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   minDeposit.Add(sdk.NewCoin("ibc/badcoin", sdk.NewInt(1000))), expErr: true,
-			options: v1.NewNonSplitVoteOption(v1.OptionYes),
+			deposit:   v1.DefaultMinDepositFloor.Add(sdk.NewCoin("ibc/badcoin", sdk.NewInt(1000))),
+			expErr:    true,
+			options:   v1.NewNonSplitVoteOption(v1.OptionYes),
 		},
 	}
 
@@ -466,7 +447,9 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 		suite.Run(name, func() {
 			proposalId := tc.preRun()
 			depositReq := v1.NewMsgDeposit(tc.depositor, proposalId, tc.deposit)
+
 			_, err := suite.msgSrvr.Deposit(suite.ctx, depositReq)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
@@ -481,10 +464,6 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 	addrs := suite.addrs
 	proposer := addrs[0]
 
-	coins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100000)))
-	initialDeposit := coins
-	minDeposit := suite.govKeeper.GetMinDeposit(suite.ctx)
-
 	cases := map[string]struct {
 		preRun func() (*v1beta1.MsgSubmitProposal, error)
 		expErr bool
@@ -493,7 +472,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 			preRun: func() (*v1beta1.MsgSubmitProposal, error) {
 				return v1beta1.NewMsgSubmitProposal(
 					v1beta1.NewTextProposal("test", "I am test"),
-					initialDeposit,
+					v1.DefaultMinInitialDepositFloor,
 					proposer,
 				)
 			},
@@ -503,7 +482,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 			preRun: func() (*v1beta1.MsgSubmitProposal, error) {
 				return v1beta1.NewMsgSubmitProposal(
 					v1beta1.NewTextProposal("test", "I am test"),
-					minDeposit,
+					v1.DefaultMinDepositFloor,
 					proposer,
 				)
 			},
@@ -515,9 +494,9 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 		suite.Run(name, func() {
 			msg, err := c.preRun()
 			suite.Require().NoError(err)
+
 			res, err := suite.legacyMsgSrvr.SubmitProposal(suite.ctx, msg)
-			// reset proposal number, we ignore the dynamic deposit system in these tests
-			suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
+
 			if c.expErr {
 				suite.Require().Error(err)
 			} else {
@@ -555,9 +534,6 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 	suite.Require().NotNil(res.ProposalId)
 	proposalId := res.ProposalId
 
-	// reset proposal number, we ignore the dynamic deposit system in these tests
-	suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 	cases := map[string]struct {
 		preRun    func() uint64
 		expErr    bool
@@ -571,7 +547,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 				bankMsg.Amount = suite.govKeeper.GetMinDeposit(suite.ctx)
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					coins,
+					v1.DefaultMinInitialDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -582,9 +558,6 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
 
 				return res.ProposalId
 			},
@@ -620,10 +593,6 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:   v1beta1.OptionYes,
@@ -637,7 +606,9 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 		suite.Run(name, func() {
 			pId := tc.preRun()
 			voteReq := v1beta1.NewMsgVote(tc.voter, pId, tc.option)
+
 			_, err := suite.legacyMsgSrvr.Vote(suite.ctx, voteReq)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 				suite.Require().Contains(err.Error(), tc.expErrMsg)
@@ -655,7 +626,6 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 	proposer := addrs[0]
 
 	coins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100000)))
-	minDeposit := suite.govKeeper.GetMinDeposit(suite.ctx)
 	bankMsg := &banktypes.MsgSend{
 		FromAddress: govAcct.String(),
 		ToAddress:   proposer.String(),
@@ -664,7 +634,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		minDeposit,
+		v1.DefaultMinDepositFloor,
 		proposer.String(),
 		"",
 		"Proposal",
@@ -676,9 +646,6 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(res.ProposalId)
 	proposalId := res.ProposalId
-
-	// reset proposal number, we ignore the dynamic deposit system in these tests
-	suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
 
 	cases := map[string]struct {
 		preRun    func() uint64
@@ -693,7 +660,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					coins,
+					v1.DefaultMinInitialDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -704,10 +671,6 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:    v1beta1.OptionYes,
@@ -730,7 +693,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					minDeposit,
+					v1.DefaultMinDepositFloor,
 					proposer.String(),
 					"",
 					"Proposal",
@@ -741,10 +704,6 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res.ProposalId)
-
-				// reset proposal number, we ignore the dynamic deposit system in these tests
-				suite.govKeeper.SetActiveProposalsNumber(suite.ctx, 0)
-
 				return res.ProposalId
 			},
 			option:   v1beta1.OptionYes,
@@ -758,7 +717,9 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 		suite.Run(name, func() {
 			pId := tc.preRun()
 			voteReq := v1beta1.NewMsgVoteWeighted(tc.voter, pId, v1beta1.NewNonSplitVoteOption(v1beta1.VoteOption(tc.option)))
+
 			_, err := suite.legacyMsgSrvr.VoteWeighted(suite.ctx, voteReq)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 				suite.Require().Contains(err.Error(), tc.expErrMsg)
@@ -775,7 +736,6 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 	proposer := addrs[0]
 
 	coins := sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100000)))
-	minDeposit := suite.govKeeper.GetMinDeposit(suite.ctx)
 	bankMsg := &banktypes.MsgSend{
 		FromAddress: govAcct.String(),
 		ToAddress:   proposer.String(),
@@ -784,18 +744,13 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		coins,
+		v1.DefaultMinInitialDepositFloor,
 		proposer.String(),
 		"",
 		"Proposal",
 		"description of proposal",
 	)
 	suite.Require().NoError(err)
-
-	res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res.ProposalId)
-	pId := res.ProposalId
 
 	cases := map[string]struct {
 		preRun     func() uint64
@@ -816,10 +771,13 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 		},
 		"all good": {
 			preRun: func() uint64 {
-				return pId
+				res, err := suite.msgSrvr.SubmitProposal(suite.ctx, msg)
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res.ProposalId)
+				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   minDeposit,
+			deposit:   v1.DefaultMinDepositFloor,
 			expErr:    false,
 			options:   v1beta1.NewNonSplitVoteOption(v1beta1.OptionYes),
 		},
@@ -829,7 +787,9 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 		suite.Run(name, func() {
 			proposalId := tc.preRun()
 			depositReq := v1beta1.NewMsgDeposit(tc.depositor, proposalId, tc.deposit)
+
 			_, err := suite.legacyMsgSrvr.Deposit(suite.ctx, depositReq)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 			} else {
@@ -1485,7 +1445,6 @@ func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 
 func (suite *KeeperTestSuite) TestProposeConstitutionAmendment() {
 	ctx := suite.ctx
-	suite.govKeeper.SetConstitution(ctx, "Hello World")
 
 	cases := map[string]struct {
 		msg       *v1.MsgProposeConstitutionAmendment
@@ -1527,7 +1486,8 @@ func (suite *KeeperTestSuite) TestProposeConstitutionAmendment() {
 
 	for name, tc := range cases {
 		suite.Run(name, func() {
-			_, err := suite.msgSrvr.ProposeConstitutionAmendment(sdk.WrapSDKContext(ctx), tc.msg)
+			suite.govKeeper.SetConstitution(suite.ctx, "Hello World")
+			_, err := suite.msgSrvr.ProposeConstitutionAmendment(suite.ctx, tc.msg)
 			if tc.expErr {
 				suite.Require().Error(err)
 				if tc.expErrMsg != "" {
@@ -1535,7 +1495,7 @@ func (suite *KeeperTestSuite) TestProposeConstitutionAmendment() {
 				}
 			} else {
 				suite.Require().NoError(err)
-				suite.Require().Equal(tc.expResult, suite.govKeeper.GetConstitution(ctx))
+				suite.Require().Equal(tc.expResult, suite.govKeeper.GetConstitution(suite.ctx))
 			}
 		})
 	}

--- a/x/gov/keeper/proposal_test.go
+++ b/x/gov/keeper/proposal_test.go
@@ -165,28 +165,8 @@ func (suite *KeeperTestSuite) TestSubmitProposal() {
 
 func (suite *KeeperTestSuite) TestGetProposalsFiltered() {
 	proposalID := uint64(1)
-	status := []v1.ProposalStatus{v1.StatusDepositPeriod, v1.StatusVotingPeriod}
 
 	addr1 := sdk.AccAddress("foo_________________")
-
-	for _, s := range status {
-		for i := 0; i < 50; i++ {
-			p, err := v1.NewProposal(TestProposal, proposalID, time.Now(), time.Now(), "", "title", "summary", sdk.AccAddress("cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r"))
-			suite.Require().NoError(err)
-
-			p.Status = s
-
-			if i%2 == 0 {
-				d := v1.NewDeposit(proposalID, addr1, nil)
-				v := v1.NewVote(proposalID, addr1, v1.NewNonSplitVoteOption(v1.OptionYes), "")
-				suite.govKeeper.SetDeposit(suite.ctx, d)
-				suite.govKeeper.SetVote(suite.ctx, v)
-			}
-
-			suite.govKeeper.SetProposal(suite.ctx, p)
-			proposalID++
-		}
-	}
 
 	testCases := []struct {
 		params             v1.QueryProposalsParams
@@ -208,6 +188,26 @@ func (suite *KeeperTestSuite) TestGetProposalsFiltered() {
 
 	for i, tc := range testCases {
 		suite.Run(fmt.Sprintf("Test Case %d", i), func() {
+			status := []v1.ProposalStatus{v1.StatusDepositPeriod, v1.StatusVotingPeriod}
+			for _, s := range status {
+				for i := 0; i < 50; i++ {
+					p, err := v1.NewProposal(TestProposal, proposalID, time.Now(), time.Now(), "", "title", "summary", sdk.AccAddress("cosmos1ghekyjucln7y67ntx7cf27m9dpuxxemn4c8g4r"))
+					suite.Require().NoError(err)
+
+					p.Status = s
+
+					if i%2 == 0 {
+						d := v1.NewDeposit(proposalID, addr1, nil)
+						v := v1.NewVote(proposalID, addr1, v1.NewNonSplitVoteOption(v1.OptionYes), "")
+						suite.govKeeper.SetDeposit(suite.ctx, d)
+						suite.govKeeper.SetVote(suite.ctx, v)
+					}
+
+					suite.govKeeper.SetProposal(suite.ctx, p)
+					proposalID++
+				}
+			}
+
 			proposals := suite.govKeeper.GetProposalsFiltered(suite.ctx, tc.params)
 			suite.Require().Len(proposals, tc.expectedNumResults)
 


### PR DESCRIPTION
State was not reinitialized between test cases, which was confusing for some scenario and forced sometimes to reset things like the deposit throttling.

The fix consists only of calling `suite.reset()` in `KeeperTestSuite.SetupSubTest()`, the other changes removes any correlation previously made by the test cases about this common state.
