### PR TITLE
test: revamp localnet Makefile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         if: env.GIT_DIFF
       - name: Start Local Network
         run: |
-          make start-localnet-ci > liveness.out 2>&1 &
+          make localnet-start > liveness.out 2>&1 &
         if: env.GIT_DIFF
       - name: Test Local Network Liveness
         run: |

--- a/Makefile
+++ b/Makefile
@@ -266,21 +266,40 @@ update-swagger-docs: proto-swagger-gen
 ###                                Localnet                                 ###
 ###############################################################################
 
-start-localnet-ci: build
-	rm -rf ~/.atomoned-liveness
-	./build/atomoned init liveness --default-denom uatone --chain-id liveness --home ~/.atomoned-liveness
-	./build/atomoned config chain-id liveness --home ~/.atomoned-liveness
-	./build/atomoned config keyring-backend test --home ~/.atomoned-liveness
-	./build/atomoned keys add val --home ~/.atomoned-liveness
-	./build/atomoned genesis add-genesis-account val 1000000000000uatone --home ~/.atomoned-liveness --keyring-backend test
-	./build/atomoned keys add user --home ~/.atomoned-liveness
-	./build/atomoned genesis add-genesis-account user 1000000000uatone --home ~/.atomoned-liveness --keyring-backend test
-	./build/atomoned genesis gentx val 1000000000uatone --home ~/.atomoned-liveness --chain-id liveness
-	./build/atomoned genesis collect-gentxs --home ~/.atomoned-liveness
-	sed -i.bak 's#^minimum-gas-prices = .*#minimum-gas-prices = "0.001uatone,0.001uphoton"#g' ~/.atomoned-liveness/config/app.toml
-	./build/atomoned start --home ~/.atomoned-liveness
+localnet_home=~/.atomone-localnet
+localnetd=./build/atomoned --home $(localnet_home)
 
-.PHONY: start-localnet-ci
+localnet-start: build
+	rm -rf ~/.atomone-localnet
+	$(localnetd) init localnet --default-denom uatone --chain-id localnet
+	$(localnetd) config chain-id localnet
+	$(localnetd) config keyring-backend test
+	$(localnetd) keys add val
+	$(localnetd) genesis add-genesis-account val 1000000000000uatone,1000000000uphoton 
+	$(localnetd) keys add user
+	$(localnetd) genesis add-genesis-account user 1000000000uatone,1000000000uphoton
+	$(localnetd) genesis gentx val 1000000000uatone 
+	$(localnetd) genesis collect-gentxs
+	sed -i.bak 's#^minimum-gas-prices = .*#minimum-gas-prices = "0.01uatone,0.01uphoton"#g' $(localnet_home)/config/app.toml
+	# enable REST API
+	sed -i -z 's/# Enable defines if the API server should be enabled.\nenable = false/enable = true/' $(localnet_home)/config/app.toml
+	# Decrease voting period to 5min
+	jq '.app_state.gov.params.voting_period = "300s"' $(localnet_home)/config/genesis.json > /tmp/gen
+	mv /tmp/gen $(localnet_home)/config/genesis.json
+	$(localnetd) start
+
+localnet-restart: build
+	$(localnetd) start
+
+localnet-submit-upgrade-proposal:
+	$(localnetd) tx gov submit-proposal --from user contrib/localnet/proposal_upgrade.json -y --gas-prices 0.02uphoton
+	sleep 5
+	$(localnetd) tx gov vote 1 yes --from val -y --gas-prices 0.02uphoton
+
+localnet-submit-text-proposal:
+	$(localnetd) tx gov submit-proposal --from user contrib/localnet/proposal_text.json -y --gas-prices 0.002uphoton
+
+.PHONY: localnet-start localnet-restart localnet-submit-upgrade-proposal localnet-submit-text-proposal
 
 ###############################################################################
 ###                                Docker                                   ###

--- a/contrib/localnet/proposal_legacy_param_change.json
+++ b/contrib/localnet/proposal_legacy_param_change.json
@@ -1,0 +1,29 @@
+{
+  "messages": [
+    {
+      "@type": "/atomone.gov.v1.MsgExecLegacyContent",
+      "content": {
+        "@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
+        "title": "IBC Transfers Enablement Proposal",
+        "description": "This proposal would enable interchain functionality, allowing AtomOne to connect and interact seamlessly with the wider Cosmos ecosystem.",
+        "changes": [
+          {
+            "subspace": "transfer",
+            "key": "SendEnabled",
+            "value": "true"
+          },
+          {
+            "subspace": "transfer",
+            "key": "ReceiveEnabled",
+            "value": "true"
+          }
+        ]
+      },
+      "authority": "atone10d07y265gmmuvt4z0w9aw880jnsr700j5z0zqt"
+    }
+  ],
+  "metadata": "ipfs://CID",
+  "deposit": "200000000uatone",
+  "title": "IBC Enablement",
+  "summary": "summary"
+}

--- a/contrib/localnet/proposal_text.json
+++ b/contrib/localnet/proposal_text.json
@@ -1,0 +1,6 @@
+{
+ "metadata": "ipfs://CID",
+ "deposit": "512000000uatone",
+ "title": "text proposal",
+ "summary": "my summary"
+}

--- a/contrib/localnet/proposal_upgrade.json
+++ b/contrib/localnet/proposal_upgrade.json
@@ -1,0 +1,19 @@
+{
+ "messages": [
+  {
+   "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+   "authority": "atone10d07y265gmmuvt4z0w9aw880jnsr700j5z0zqt",
+   "plan": {
+    "name": "v2",
+    "time": "0001-01-01T00:00:00Z",
+    "height": "80",
+    "info": "",
+    "upgraded_client_state": null
+   }
+  }
+ ],
+ "metadata": "ipfs://CID",
+ "deposit": "512000000uatone",
+ "title": "v2",
+ "summary": "v2"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ localnet.
 3. Run `make localnet-start` to start a new localnet.
 4. Run `make localnet-submit-upgrade-proposal` to submit the upgrade proposal
    and give it enough yes votes for passing the tally.
-5. Wait for 5 minutes and run `atomoned --home ~/.atomone-localnet q gov proposals`
+5. Wait for 5 minutes (the voting period) and run `atomoned --home ~/.atomone-localnet q gov proposals`
    to check that the proposal has passed.
 6. Wait for the block height that was registered in the upgrade proposal. Once
    reached the localnet should stop producing blocks, and return an error like:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,36 @@ parent:
 layout: home
 -->
 
-# GovGen Documentation
+# AtomOne Documentation
 
 Welcome to the documentation of the **AtomOne application: `atomone`**.
+
+## Testing Chain Upgrade
+
+Chain upgrade is an important procedure that should be tested carefully. This
+section aims to provide a guide for testing chain upgrades in AtomOne using a
+localnet. 
+
+1. Git checkout the version of AtomOne you want to upgrade from.
+2. Update `contrib/localnet/upgrade_proposal.json` with the correct plan name,
+   which means the exact `UpgradeName` used to qualify the upgrade in the
+   next version. For instance for the v2 upgrade, the plan name is `v2` (see
+   the `app/upgrade` folder).
+3. Run `make localnet-start` to start a new localnet.
+4. Run `make localnet-submit-upgrade-proposal` to submit the upgrade proposal
+   and give it enough yes votes for passing the tally.
+5. Wait for 5 minutes and run `atomoned --home ~/.atomone-localnet q gov proposals`
+   to check that the proposal has passed.
+6. Wait for the block height that was registered in the upgrade proposal. Once
+   reached the localnet should stop producing blocks, and return an error like:
+   ```
+   ERR UPGRADE "v2" NEEDED (...)
+   ERR CONSENSUS FAILURE!!!
+   ```
+   This means it is time to upgrade the binary.
+7. Stop the `make localnet-start`
+8. Git checkout the version of AtomOne you want to upgrade to.
+9. Run `make localnet-restart` (/!\ not `localnet-start` which would delete all
+   the chain data). Block production should restart.
+10. Check that the upgrade procedure has been executed properly.
+


### PR DESCRIPTION
`start-localnet-ci` is renamed `localnet-start` because I want the target to be more usable and not namely tied to CI processes. Some other target `localnet-*` are added to simplify some other tasks like submitting proposals.

Target itself is improved by adding photon balances to the genesis accounts, enabling REST API and reducing the voting period to 5min.

A short documentation is added to describe how to test a chain upgrade using a gov software upgrade proposal.

