### PR TITLE
docs: fix typos in `x/photon` ADR

### DIFF
--- a/docs/architecture/adr-002-photon-token.md
+++ b/docs/architecture/adr-002-photon-token.md
@@ -99,7 +99,7 @@ decorator to the `AnteHandler`. Just before the `auth/ante.DeductFeeDecorator`,
 we want to add a decorator that should:
 
 - enforce that the fee denom is `uphoton`, and return a specific error message if
-  it does not (this to be explicitely separated with the insufficient fee error
+  it does not (this to be explicitly separated with the insufficient fee error
   message)
 - make exception for some messages, specifically like `MsgMintPhoton`, because
   `MsgMintPhoton` is the only way to get PHOTONs, so it should accept ATONEs as
@@ -116,7 +116,7 @@ The `photon` module has the following params:
 
 ### State
 
-Aside from its params, the `x/photon` module does not have any additionnal state,
+Aside from its params, the `x/photon` module does not have any additional state,
 as the PHOTON balances and supply are handled by the `x/bank` module.
 
 ### Migration
@@ -194,7 +194,7 @@ provided by the `x/photon` module).
   inflate between the 7% and 20% bounds,targeting the 2/3 bonding ratio.
   PHOTON as the fee token reinforces this property.
 
-- Having a non-inflationnary fee token (in contrast to ATONE) ensures PHOTON
+- Having a non-inflationary fee token (in contrast to ATONE) ensures PHOTON
   will not be subject to the same dilution tax for non-stakers as ATONE does.
   PHOTON holders will be subject to no dilution at all. The more stable nature
   of PHOTON  makes it a perfect candidate for a fee token.
@@ -208,7 +208,7 @@ provided by the `x/photon` module).
 ### Neutral
 
 - Dual token model like this has not been experimented at this scale in the
-  Cosmos ecosytem, we might experience some unexpected side effect, positive or
+  Cosmos ecosystem, we might experience some unexpected side effect, positive or
   negative.
 
 ## References


### PR DESCRIPTION
## Description

Fix minor typos in ADR
Same changes as https://github.com/atomone-hub/atomone-docs/pull/10

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/atomone-hub/atomone/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for thoroughness
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)

