### PR TITLE
fix: remove the crisis module key from keys list

### DIFF
--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -12,7 +12,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
@@ -48,11 +47,6 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 		authzkeeper.StoreKey,
 		consensusparamtypes.StoreKey,
 		photontypes.StoreKey,
-		// TODO: to be removed in a future release, since x/crisis
-		// was deprecated. The key had to be left here to facilitate
-		// deletion of the module's state from the store during the
-		// software upgrade.
-		crisistypes.StoreKey,
 	)
 
 	// Define transient store keys


### PR DESCRIPTION
The key was initially kept to perform the deletion of the store, but then the node is not able to restart because the store was expected to have the key.

Error: `failed to load latest version: failed to load latest version: version of store crisis mismatch root store's version; expected 45 got 0; new stores should be added using StoreUpgrades`
