### PR TITLE
fix: ensures correct denom when minting photon

### DIFF
--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -833,7 +833,6 @@ func (s *IntegrationTestSuite) execPhotonMint(
 	valIdx int,
 	from,
 	amt string,
-	gasAuto bool,
 	expectFail bool,
 	opt ...flagOption,
 ) (resp photontypes.MsgMintPhotonResponse) {
@@ -854,9 +853,7 @@ func (s *IntegrationTestSuite) execPhotonMint(
 		"-y",
 	}
 	for flag, value := range opts {
-		if gasAuto || flag != flagGas {
-			atomoneCommand = append(atomoneCommand, fmt.Sprintf("--%s=%v", flag, value))
-		}
+		atomoneCommand = append(atomoneCommand, fmt.Sprintf("--%s=%v", flag, value))
 	}
 
 	if !expectFail {

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -762,7 +762,12 @@ func (s *IntegrationTestSuite) expectErrExecValidation(chain *chain, valIdx int,
 		// wait for the tx to be committed on chain
 		s.Require().Eventuallyf(
 			func() bool {
-				gotErr := queryAtomOneTx(endpoint, txResp.TxHash, nil) != nil
+				resp := queryAtomOneTx(endpoint, txResp.TxHash, nil)
+				if isErrNotFound(resp) {
+					// tx not processed yet, continue
+					return !expectErr
+				}
+				gotErr := resp != nil
 				return gotErr == expectErr
 			},
 			time.Minute,

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -833,6 +833,8 @@ func (s *IntegrationTestSuite) execPhotonMint(
 	valIdx int,
 	from,
 	amt string,
+	gasAuto bool,
+	expectFail bool,
 	opt ...flagOption,
 ) (resp photontypes.MsgMintPhotonResponse) {
 	opt = append(opt, withKeyValue(flagFrom, from))
@@ -852,10 +854,16 @@ func (s *IntegrationTestSuite) execPhotonMint(
 		"-y",
 	}
 	for flag, value := range opts {
-		atomoneCommand = append(atomoneCommand, fmt.Sprintf("--%s=%v", flag, value))
+		if gasAuto || flag != flagGas {
+			atomoneCommand = append(atomoneCommand, fmt.Sprintf("--%s=%v", flag, value))
+		}
 	}
 
-	s.executeAtomoneTxCommand(ctx, c, atomoneCommand, valIdx, s.defaultExecValidation(c, valIdx, &resp))
+	if !expectFail {
+		s.executeAtomoneTxCommand(ctx, c, atomoneCommand, valIdx, s.defaultExecValidation(c, valIdx, &resp))
+	} else {
+		s.executeAtomoneTxCommand(ctx, c, atomoneCommand, valIdx, s.expectErrExecValidation(c, valIdx, true))
+	}
 	return
 }
 

--- a/tests/e2e/e2e_photon_test.go
+++ b/tests/e2e/e2e_photon_test.go
@@ -56,7 +56,7 @@ func (s *IntegrationTestSuite) testMintPhoton() {
 	s.Run("mint photon", subtest(standardFees))
 	atoneFees := sdk.NewCoin(uatoneDenom, standardFees.Amount)
 	s.Run("mint photon with atone fees", subtest(atoneFees))
-	s.Run("mint photon wrong denom", func() {
+	s.Run("mint photon wrong denom does not deduct fees", func() {
 		var (
 			c             = s.chainA
 			valIdx        = 0

--- a/tests/e2e/e2e_photon_test.go
+++ b/tests/e2e/e2e_photon_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -71,7 +70,6 @@ func (s *IntegrationTestSuite) testMintPhoton() {
 		_ = s.execPhotonMint(s.chainA, valIdx, alice.String(), "1000wrongDenom",
 			true, withKeyValue(flagGas, "200000"))
 
-		time.Sleep(1 * time.Second)
 		afterBalance, err := queryAtomOneAllBalances(chainEndpoint, alice.String())
 
 		var (

--- a/tests/e2e/e2e_photon_test.go
+++ b/tests/e2e/e2e_photon_test.go
@@ -81,6 +81,9 @@ func (s *IntegrationTestSuite) testMintPhoton() {
 			_, afterUatoneBalance  = afterBalance.Find(uatoneDenom)
 		)
 
-		s.Require().True(beforeUatoneBalance.IsEqual(afterUatoneBalance), "Fees should not be deducted for a malformed tx\nAlice balance before tx: %s\nAlice balance after tx: %s", beforeUatoneBalance, afterUatoneBalance)
+		s.Require().True(beforeUatoneBalance.IsEqual(afterUatoneBalance),
+			"Fees should not be deducted for a malformed tx\n"+
+				"Balance before tx: %s != Balance after tx: %s",
+			beforeUatoneBalance, afterUatoneBalance)
 	})
 }

--- a/tests/e2e/e2e_photon_test.go
+++ b/tests/e2e/e2e_photon_test.go
@@ -24,7 +24,7 @@ func (s *IntegrationTestSuite) testMintPhoton() {
 			burnedAtoneAmt := sdk.NewInt64Coin(uatoneDenom, 1_000_000)
 
 			resp := s.execPhotonMint(s.chainA, valIdx, alice.String(), burnedAtoneAmt.String(),
-				true, false, withKeyValue(flagFees, fees),
+				false, withKeyValue(flagFees, fees),
 			)
 
 			expectedBalance := beforeBalance.
@@ -64,26 +64,30 @@ func (s *IntegrationTestSuite) testMintPhoton() {
 		)
 		alice, _ := c.genesisAccounts[1].keyInfo.GetAddress()
 
-		atoneFees := sdk.NewCoin(uatoneDenom, standardFees.Amount)
 		beforeBalance, err := queryAtomOneAllBalances(chainEndpoint, alice.String())
 		s.Require().NoError(err)
 
 		// Issue an incorrect transaction with wrong Denom
 		_ = s.execPhotonMint(s.chainA, valIdx, alice.String(), "1000wrongDenom",
-			false, true, withKeyValue(flagFees, atoneFees),
-		)
+			true, withKeyValue(flagGas, "200000"))
 
 		time.Sleep(1 * time.Second)
 		afterBalance, err := queryAtomOneAllBalances(chainEndpoint, alice.String())
 
 		var (
-			_, beforeUatoneBalance = beforeBalance.Find(uatoneDenom)
-			_, afterUatoneBalance  = afterBalance.Find(uatoneDenom)
+			_, beforeUphotonBalance = beforeBalance.Find(uphotonDenom)
+			_, afterUphotonBalance  = afterBalance.Find(uphotonDenom)
+			_, beforeUatoneBalance  = beforeBalance.Find(uatoneDenom)
+			_, afterUatoneBalance   = afterBalance.Find(uatoneDenom)
 		)
 
 		s.Require().True(beforeUatoneBalance.IsEqual(afterUatoneBalance),
 			"Fees should not be deducted for a malformed tx\n"+
 				"Balance before tx: %s != Balance after tx: %s",
 			beforeUatoneBalance, afterUatoneBalance)
+		s.Require().True(beforeUphotonBalance.IsEqual(afterUphotonBalance),
+			"Fees should not be deducted for a malformed tx\n"+
+				"Balance before tx: %s != Balance after tx: %s",
+			beforeUphotonBalance, afterUphotonBalance)
 	})
 }

--- a/x/photon/simulation/operations.go
+++ b/x/photon/simulation/operations.go
@@ -10,6 +10,7 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
+	"github.com/atomone-hub/atomone/app/params"
 	"github.com/atomone-hub/atomone/x/photon/keeper"
 	"github.com/atomone-hub/atomone/x/photon/types"
 )
@@ -62,7 +63,7 @@ func SimulateMsgMintPhoton(
 		if len(spendable) == 0 {
 			return simtypes.NoOpMsg(types.ModuleName, TypeMsgMintPhoton, "no spendable coins"), nil, nil
 		}
-		bondDenom := sk.BondDenom(ctx)
+		bondDenom := params.BondDenom
 		ok, amount := spendable.Find(bondDenom)
 		if !ok {
 			return simtypes.NoOpMsg(types.ModuleName, TypeMsgMintPhoton, "no bond denom in spendable coins"), nil, nil

--- a/x/photon/types/msgs.go
+++ b/x/photon/types/msgs.go
@@ -50,7 +50,7 @@ func (msg *MsgMintPhoton) ValidateBasic() error {
 	}
 	// Ensure burned amount denom is bond denom
 	if msg.Amount.Denom != params.BondDenom {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, "coin must be a bonded denom")
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, ErrBurnInvalidDenom.Error())
 	}
 	return nil
 }

--- a/x/photon/types/msgs.go
+++ b/x/photon/types/msgs.go
@@ -50,7 +50,7 @@ func (msg *MsgMintPhoton) ValidateBasic() error {
 	}
 	// Ensure burned amount denom is bond denom
 	if msg.Amount.Denom != params.BondDenom {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, ErrBurnInvalidDenom.Error())
+		return errorsmod.Wrapf(ErrBurnInvalidDenom, "invalid denom %s", msg.Amount.Denom)
 	}
 	return nil
 }

--- a/x/photon/types/msgs.go
+++ b/x/photon/types/msgs.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	"github.com/atomone-hub/atomone/app/params"
 	"github.com/atomone-hub/atomone/x/gov/types"
 )
 
@@ -48,8 +49,7 @@ func (msg *MsgMintPhoton) ValidateBasic() error {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, "coin to burn must be positive")
 	}
 	// Ensure burned amount denom is bond denom
-	bondDenom := "uatone"
-	if msg.Amount.Denom != bondDenom {
+	if msg.Amount.Denom != params.BondDenom {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, "coin must be a bonded denom")
 	}
 	return nil

--- a/x/photon/types/msgs.go
+++ b/x/photon/types/msgs.go
@@ -47,6 +47,11 @@ func (msg *MsgMintPhoton) ValidateBasic() error {
 	if !msg.Amount.IsPositive() {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, "coin to burn must be positive")
 	}
+	// Ensure burned amount denom is bond denom
+	bondDenom := "uatone"
+	if msg.Amount.Denom != bondDenom {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidCoins, "coin must be a bonded denom")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## fix(x/photon): add denom check on mint transaction

This PR fixes an issue that could arise if a user typed the wrong denom when issuing a photon mint transaction, for example:

`atomoned tx photon mint 1000`**wrongdenom**` -y --home=/path/to/home --fees=330000uatone --keyring-backend=test --output=json  --from=wallet --broadcast-mode=sync --chain-id=chain_name`

Even though the transaction is incorrect, without this fix, the fees would be charged to the user.