### PR TITLE
test(e2e): split e2e test setup phase and separated IBC setup

### DIFF
--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -13,7 +13,6 @@ import (
 
 //nolint:unparam
 func (s *IntegrationTestSuite) sendIBC(c *chain, valIdx int, sender, recipient, token, note string) {
-	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -42,7 +41,6 @@ func (s *IntegrationTestSuite) sendIBC(c *chain, valIdx int, sender, recipient, 
 }
 
 func (s *IntegrationTestSuite) hermesTransfer(configPath, srcChainID, dstChainID, srcChannelID, denom string, sendAmt, timeOutOffset, numMsg int) (success bool) {
-	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -70,7 +68,6 @@ func (s *IntegrationTestSuite) hermesTransfer(configPath, srcChainID, dstChainID
 }
 
 func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID string) (success bool) { //nolint:unparam
-	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -105,7 +102,6 @@ type RelayerPacketsOutput struct {
 }
 
 func (s *IntegrationTestSuite) hermesPendingPackets(chainID, channelID string) (pendingPackets bool) { //nolint:unparam
-	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	hermesCmd := []string{
@@ -131,7 +127,6 @@ func (s *IntegrationTestSuite) hermesPendingPackets(chainID, channelID string) (
 }
 
 func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin) {
-	s.ensureIBCSetup()
 	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
 	acctAddrChainA, _ := s.chainA.genesisAccounts[relayerAccountIndexHermes].keyInfo.GetAddress()
 	scrRelayerBalance, err := getSpecificBalance(
@@ -152,7 +147,6 @@ func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin
 }
 
 func (s *IntegrationTestSuite) createConnection() {
-	s.ensureIBCSetup()
 	s.T().Logf("connecting %s and %s chains via IBC", s.chainA.id, s.chainB.id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -176,7 +170,6 @@ func (s *IntegrationTestSuite) createConnection() {
 }
 
 func (s *IntegrationTestSuite) createChannel() {
-	s.ensureIBCSetup()
 	s.T().Logf("creating IBC transfer channel created between chains %s and %s", s.chainA.id, s.chainB.id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -201,7 +194,6 @@ func (s *IntegrationTestSuite) createChannel() {
 }
 
 func (s *IntegrationTestSuite) testIBCTokenTransfer() {
-	s.ensureIBCSetup()
 	s.Run("send_uatom_to_chainB", func() {
 		// require the recipient account receives the IBC tokens (IBC packets ACKd)
 		var (

--- a/tests/e2e/e2e_ibc_test.go
+++ b/tests/e2e/e2e_ibc_test.go
@@ -13,6 +13,7 @@ import (
 
 //nolint:unparam
 func (s *IntegrationTestSuite) sendIBC(c *chain, valIdx int, sender, recipient, token, note string) {
+	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -41,6 +42,7 @@ func (s *IntegrationTestSuite) sendIBC(c *chain, valIdx int, sender, recipient, 
 }
 
 func (s *IntegrationTestSuite) hermesTransfer(configPath, srcChainID, dstChainID, srcChannelID, denom string, sendAmt, timeOutOffset, numMsg int) (success bool) {
+	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -68,6 +70,7 @@ func (s *IntegrationTestSuite) hermesTransfer(configPath, srcChainID, dstChainID
 }
 
 func (s *IntegrationTestSuite) hermesClearPacket(configPath, chainID, channelID string) (success bool) { //nolint:unparam
+	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -102,6 +105,7 @@ type RelayerPacketsOutput struct {
 }
 
 func (s *IntegrationTestSuite) hermesPendingPackets(chainID, channelID string) (pendingPackets bool) { //nolint:unparam
+	s.ensureIBCSetup()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	hermesCmd := []string{
@@ -127,6 +131,7 @@ func (s *IntegrationTestSuite) hermesPendingPackets(chainID, channelID string) (
 }
 
 func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin) {
+	s.ensureIBCSetup()
 	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
 	acctAddrChainA, _ := s.chainA.genesisAccounts[relayerAccountIndexHermes].keyInfo.GetAddress()
 	scrRelayerBalance, err := getSpecificBalance(
@@ -147,6 +152,7 @@ func (s *IntegrationTestSuite) queryRelayerWalletsBalances() (sdk.Coin, sdk.Coin
 }
 
 func (s *IntegrationTestSuite) createConnection() {
+	s.ensureIBCSetup()
 	s.T().Logf("connecting %s and %s chains via IBC", s.chainA.id, s.chainB.id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -170,6 +176,7 @@ func (s *IntegrationTestSuite) createConnection() {
 }
 
 func (s *IntegrationTestSuite) createChannel() {
+	s.ensureIBCSetup()
 	s.T().Logf("creating IBC transfer channel created between chains %s and %s", s.chainA.id, s.chainB.id)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -194,6 +201,7 @@ func (s *IntegrationTestSuite) createChannel() {
 }
 
 func (s *IntegrationTestSuite) testIBCTokenTransfer() {
+	s.ensureIBCSetup()
 	s.Run("send_uatom_to_chainB", func() {
 		// require the recipient account receives the IBC tokens (IBC packets ACKd)
 		var (

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -64,10 +64,10 @@ func (s *IntegrationTestSuite) TestGov() {
 }
 
 func (s *IntegrationTestSuite) TestIBC() {
-	s.ensureIBCSetup()
 	if !runIBCTest {
 		s.T().Skip()
 	}
+	s.ensureIBCSetup()
 
 	s.testIBCTokenTransfer()
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -64,6 +64,7 @@ func (s *IntegrationTestSuite) TestGov() {
 }
 
 func (s *IntegrationTestSuite) TestIBC() {
+	s.ensureIBCSetup()
 	if !runIBCTest {
 		s.T().Skip()
 	}


### PR DESCRIPTION
## Description

This PR splits the setup and teardown of the e2e tests into phases. The first setup phase is executed at the beginning of any e2e test and initializes only one chain, without setting up the secondary chain and IBC. The second phase is lazily executed when IBC is needed and performs the IBC setup. 
For most of the tests IBC is not required, and this PR gives substantial speedup on single e2e tests (see below).

The only additional requirement for this PR to work is that any tests that requires IBC to be setup, should start with a call to `s.ensureIBCSetup()`.

Split Setup Phases times:
All e2e tests: 390s
TestPhoton e2e tests: 13s

Current e2e times:
All e2e tests: 469s
TestPhoton e2e tests: 94s
