### PR TITLE
chore(x/feemarket): Fixed lt and gt in documentation to reflect the implementation

### DIFF
--- a/x/feemarket/AIMD.md
+++ b/x/feemarket/AIMD.md
@@ -74,7 +74,7 @@ The calculation for the updated base fee for the next block is as follows:
 // sumBlockSizesInWindow returns the sum of the block sizes in the window.
 blockConsumption := sumBlockSizesInWindow(window) / (window * maxBlockSize)
 
-if blockConsumption < gamma || blockConsumption > 1 - gamma {
+if blockConsumption <= gamma || blockConsumption >= 1 - gamma {
     // MAX_LEARNING_RATE is a constant that is configured by the chain developer
     newLearningRate := min(MaxLearningRate, alpha + currentLearningRate)
 } else {


### PR DESCRIPTION
Description

The documentation AIMD.md is not in line with the [code](https://github.com/atomone-hub/atomone/blob/feat/x/feemarket/x/feemarket/types/state.go#L109):

`	if avg.LTE(params.Gamma) || avg.GTE(math.LegacyOneDec().Sub(params.Gamma)) {`