### PR TITLE
chore(x/feemarket): Refactored Utilization and Size to Gas in feemarket module

### DIFF
--- a/x/feemarket/README.md
+++ b/x/feemarket/README.md
@@ -38,7 +38,7 @@ branch) and includes changes and adaptations to suit the AtomOne project.
     - [MinBaseGasPrice](#minbasegasprice)
     - [MinLearningRate](#minlearningrate)
     - [MaxLearningRate](#maxlearningrate)
-    - [MaxBlockUtilization](#maxblockutilization)
+    - [MaxBlockGas](#maxblockgas)
     - [Window](#window-1)
     - [FeeDenom](#feedenom)
     - [Enabled](#enabled)
@@ -252,9 +252,9 @@ MinLearningRate is the lower bound for the learning rate.
 
 MaxLearningRate is the upper bound for the learning rate.
 
-### MaxBlockUtilization
+### MaxBlockGas
 
-MaxBlockUtilization is the maximum block utilization. Once this has been surpassed,
+MaxBlockGas is the maximum block gas. Once this has been surpassed,
 no more transactions will be added to the current block.
 
 ### Window
@@ -331,8 +331,8 @@ message Params {
     (gogoproto.nullable) = false
   ];
 
-  // MaxBlockUtilization is the maximum block utilization.
-  uint64 max_block_utilization = 8;
+  // MaxBlockGas is the maximum block gas.
+  uint64 max_block_gas = 8;
 
   // Window defines the window size for calculating an adaptive learning rate
   // over a moving window of blocks.

--- a/x/feemarket/fuzz/eip1559_test.go
+++ b/x/feemarket/fuzz/eip1559_test.go
@@ -21,11 +21,11 @@ func TestLearningRate(t *testing.T) {
 		// Randomly generate alpha and beta.
 		prevLearningRate := state.LearningRate
 
-		// Randomly generate the block utilization.
-		blockUtilization := rapid.Uint64Range(0, maxBlockGas).Draw(t, "gas")
+		// Randomly generate the block gas.
+		blockGas := rapid.Uint64Range(0, maxBlockGas).Draw(t, "gas")
 
 		// Update the fee market.
-		if err := state.Update(blockUtilization, maxBlockGas); err != nil {
+		if err := state.Update(blockGas, maxBlockGas); err != nil {
 			t.Fatalf("block update errors: %v", err)
 		}
 
@@ -47,11 +47,11 @@ func TestGasPrice(t *testing.T) {
 		prevBaseGasPrice := state.BaseGasPrice.Mul(math.LegacyNewDec(11)).Quo(math.LegacyNewDec(10))
 		state.BaseGasPrice = prevBaseGasPrice
 
-		// Randomly generate the block utilization.
-		blockUtilization := rapid.Uint64Range(0, maxBlockGas).Draw(t, "gas")
+		// Randomly generate the block gas.
+		blockGas := rapid.Uint64Range(0, maxBlockGas).Draw(t, "gas")
 
 		// Update the fee market.
-		if err := state.Update(blockUtilization, maxBlockGas); err != nil {
+		if err := state.Update(blockGas, maxBlockGas); err != nil {
 			t.Fatalf("block update errors: %v", err)
 		}
 
@@ -64,9 +64,9 @@ func TestGasPrice(t *testing.T) {
 		require.True(t, params.MinBaseGasPrice.LTE(state.BaseGasPrice))
 
 		switch {
-		case blockUtilization > types.GetTargetBlockUtilization(maxBlockGas):
+		case blockGas > types.GetTargetBlockGas(maxBlockGas):
 			require.True(t, state.BaseGasPrice.GTE(prevBaseGasPrice))
-		case blockUtilization < types.GetTargetBlockUtilization(maxBlockGas):
+		case blockGas < types.GetTargetBlockGas(maxBlockGas):
 			require.True(t, state.BaseGasPrice.LTE(prevBaseGasPrice))
 		default:
 			require.Equal(t, state.BaseGasPrice, prevBaseGasPrice)
@@ -86,12 +86,12 @@ func CreateRandomParams(t *rapid.T) (types.Params, uint64) {
 	g := rapid.Uint64Range(10, 50).Draw(t, "gamma")
 	gamma := math.LegacyNewDec(int64(g)).Quo(math.LegacyNewDec(100))
 
-	maxBlockUtilization := rapid.Uint64Range(2, 30_000_000).Draw(t, "max_block_utilization")
+	maxBlockGas := rapid.Uint64Range(2, 30_000_000).Draw(t, "max_block_gas")
 
 	params := types.DefaultParams()
 	params.Alpha = alpha
 	params.Beta = beta
 	params.Gamma = gamma
 
-	return params, maxBlockUtilization
+	return params, maxBlockGas
 }

--- a/x/feemarket/keeper/feemarket.go
+++ b/x/feemarket/keeper/feemarket.go
@@ -49,8 +49,8 @@ func (k *Keeper) UpdateFeeMarket(ctx sdk.Context) error {
 		"height", ctx.BlockHeight(),
 		"new_base_gas_price", newBaseGasPrice,
 		"new_learning_rate", newLR,
-		"average_block_utilization", state.GetAverageUtilization(maxBlockGas),
-		"net_block_utilization", state.GetNetUtilization(maxBlockGas),
+		"average_block_utilization", state.GetAverageGas(maxBlockGas),
+		"net_block_utilization", state.GetNetGas(maxBlockGas),
 	)
 
 	// Increment the height of the state and set the new state.

--- a/x/feemarket/keeper/feemarket_test.go
+++ b/x/feemarket/keeper/feemarket_test.go
@@ -112,7 +112,7 @@ func TestUpdateFeeMarket(t *testing.T) {
 
 		// Reaching the target block size means that we expect this to not
 		// increase.
-		err := state.Update(types.GetTargetBlockUtilization(testutil.MaxBlockGas), testutil.MaxBlockGas)
+		err := state.Update(types.GetTargetBlockGas(testutil.MaxBlockGas), testutil.MaxBlockGas)
 		require.NoError(err)
 
 		k.InitGenesis(ctx, types.GenesisState{Params: params, State: state})
@@ -138,7 +138,7 @@ func TestUpdateFeeMarket(t *testing.T) {
 		state.BaseGasPrice = state.BaseGasPrice.Mul(math.LegacyNewDec(2))
 		// Reaching the target block size means that we expect this to not
 		// increase.
-		err := state.Update(types.GetTargetBlockUtilization(testutil.MaxBlockGas), testutil.MaxBlockGas)
+		err := state.Update(types.GetTargetBlockGas(testutil.MaxBlockGas), testutil.MaxBlockGas)
 		require.NoError(err)
 
 		k.InitGenesis(ctx, types.GenesisState{Params: params, State: state})
@@ -400,7 +400,7 @@ func TestUpdateFeeMarket(t *testing.T) {
 		// Reaching the target block size means that we expect this to not
 		// increase.
 		for i := 0; i < len(state.Window); i++ {
-			state.Window[i] = types.GetTargetBlockUtilization(testutil.MaxBlockGas)
+			state.Window[i] = types.GetTargetBlockGas(testutil.MaxBlockGas)
 		}
 
 		k.InitGenesis(ctx, types.GenesisState{Params: params, State: state})
@@ -429,7 +429,7 @@ func TestUpdateFeeMarket(t *testing.T) {
 		// Reaching the target block size means that we expect this to not
 		// increase.
 		for i := 0; i < len(state.Window); i++ {
-			state.Window[i] = types.GetTargetBlockUtilization(testutil.MaxBlockGas)
+			state.Window[i] = types.GetTargetBlockGas(testutil.MaxBlockGas)
 		}
 
 		k.InitGenesis(ctx, types.GenesisState{Params: params, State: state})

--- a/x/feemarket/types/state_fuzz_test.go
+++ b/x/feemarket/types/state_fuzz_test.go
@@ -55,7 +55,7 @@ func FuzzDefaultFeeMarket(f *testing.F) {
 		oldFee := state.BaseGasPrice
 		newFee := state.UpdateBaseGasPrice(params, testutil.MaxBlockGas)
 
-		if blockGasUsed > types.GetTargetBlockUtilization(testutil.MaxBlockGas) {
+		if blockGasUsed > types.GetTargetBlockGas(testutil.MaxBlockGas) {
 			require.True(t, newFee.GT(oldFee))
 		} else {
 			require.True(t, newFee.LT(oldFee))
@@ -98,7 +98,7 @@ func FuzzAIMDFeeMarket(f *testing.F) {
 		oldFee := state.BaseGasPrice
 		newFee := state.UpdateBaseGasPrice(params, testutil.MaxBlockGas)
 
-		if blockGasUsed > types.GetTargetBlockUtilization(testutil.MaxBlockGas) {
+		if blockGasUsed > types.GetTargetBlockGas(testutil.MaxBlockGas) {
 			require.True(t, newFee.GT(oldFee))
 		} else {
 			require.True(t, newFee.LT(oldFee))


### PR DESCRIPTION
# Description

The feemarket module and tests improperly use the terms `Size` and `Utilization` to refer to `Gas`.
This PR refactors these instances where appropriate.