### PR TITLE
feat(v3/upgrade): add v3 upgrade code to mint photon from 90% of atone funds of Community Pool and Treasury DAO address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,16 @@ localnet-start: build
 	$(localnetd) genesis add-genesis-account user 1000000000uatone,1000000000uphoton
 	$(localnetd) genesis gentx val 1000000000uatone 
 	$(localnetd) genesis collect-gentxs
+	# Add treasury DAO address
+	$(localnetd) genesis add-genesis-account atone1qqqqqqqqqqqqqqqqqqqqqqqqqqqqp0dqtalx52 5388766663072uatone
+	# Add CP funds
+	$(localnetd) genesis add-genesis-account atone1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8flcml8 5388766663072uatone
+	jq '.app_state.distribution.fee_pool.community_pool = [ { "denom": "uatone", "amount": "5388766663072.000000000000000000" }]' $(localnet_home)/config/genesis.json > /tmp/gen
+	mv /tmp/gen $(localnet_home)/config/genesis.json
+	# Previous add-genesis-account call added the auth module account as a BaseAccount, we need to remove it
+	jq 'del(.app_state.auth.accounts[] | select(.address == "atone1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8flcml8"))' $(localnet_home)/config/genesis.json > /tmp/gen
+	mv /tmp/gen $(localnet_home)/config/genesis.json
+	# Set validator gas prices
 	sed -i.bak 's#^minimum-gas-prices = .*#minimum-gas-prices = "0.01uatone,0.01uphoton"#g' $(localnet_home)/config/app.toml
 	# enable REST API
 	sed -i -z 's/# Enable defines if the API server should be enabled.\nenable = false/enable = true/' $(localnet_home)/config/app.toml

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -8,6 +8,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/atomone-hub/atomone/app/keepers"
+	appparams "github.com/atomone-hub/atomone/app/params"
 	govkeeper "github.com/atomone-hub/atomone/x/gov/keeper"
 	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
 	photontypes "github.com/atomone-hub/atomone/x/photon/types"
@@ -70,7 +71,7 @@ func convertFundsToPhoton(ctx sdk.Context, keepers *keepers.AppKeepers) error {
 
 	// Get treasury DAO address
 	treasuryAddrBz := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xbd\xa0")
-	treasuryAddr := sdk.MustBech32ifyAddressBytes("atone", treasuryAddrBz)
+	treasuryAddr := sdk.MustBech32ifyAddressBytes(appparams.Bech32PrefixAccAddr, treasuryAddrBz)
 
 	// Process community pool funds
 	if err := convertCommunityPoolFundsToPhoton(ctx, keepers, bondDenom); err != nil {

--- a/app/upgrades/v3/upgrades.go
+++ b/app/upgrades/v3/upgrades.go
@@ -10,6 +10,7 @@ import (
 	"github.com/atomone-hub/atomone/app/keepers"
 	govkeeper "github.com/atomone-hub/atomone/x/gov/keeper"
 	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+	photontypes "github.com/atomone-hub/atomone/x/photon/types"
 )
 
 // CreateUpgradeHandler returns a upgrade handler for AtomOne v3
@@ -29,6 +30,10 @@ func CreateUpgradeHandler(
 		if err := initGovDynamicQuorum(ctx, keepers.GovKeeper); err != nil {
 			return vm, err
 		}
+		if err := convertFundsToPhoton(ctx, keepers); err != nil {
+			return vm, err
+		}
+
 		ctx.Logger().Info("Upgrade complete")
 		return vm, nil
 	}
@@ -53,5 +58,153 @@ func initGovDynamicQuorum(ctx sdk.Context, govKeeper *govkeeper.Keeper) error {
 	govKeeper.SetConstitutionAmendmentParticipationEMA(ctx, initParticipationEma)
 	govKeeper.SetLawParticipationEMA(ctx, initParticipationEma)
 	ctx.Logger().Info("Gov module initialized for dynamic quorum")
+	return nil
+}
+
+// convertFundsToPhoton converts 90% of the bond denom (uatone) funds from community pool and treasury DAO to photons (uphoton)
+func convertFundsToPhoton(ctx sdk.Context, keepers *keepers.AppKeepers) error {
+	ctx.Logger().Info("Converting 90% of bond denom funds to photons...")
+
+	// Get bond denom
+	bondDenom := keepers.StakingKeeper.BondDenom(ctx)
+
+	// Get treasury DAO address
+	treasuryAddrBz := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xbd\xa0")
+	treasuryAddr := sdk.MustBech32ifyAddressBytes("atone", treasuryAddrBz)
+
+	// Process community pool funds
+	if err := convertCommunityPoolFundsToPhoton(ctx, keepers, bondDenom); err != nil {
+		return fmt.Errorf("failed to convert community pool funds: %w", err)
+	}
+
+	// Process treasury DAO funds
+	if err := convertTreasuryDAOFundsToPhoton(ctx, keepers, bondDenom, treasuryAddr); err != nil {
+		return fmt.Errorf("failed to convert treasury DAO funds: %w", err)
+	}
+
+	ctx.Logger().Info("Successfully converted funds to photons")
+	return nil
+}
+
+// convertCommunityPoolFundsToPhoton converts 90% of the community pool bond denom funds to photons
+func convertCommunityPoolFundsToPhoton(ctx sdk.Context, keepers *keepers.AppKeepers, bondDenom string) error {
+	// Get community pool funds
+	communityPoolCoins := keepers.DistrKeeper.GetFeePoolCommunityCoins(ctx)
+	bondDenomCoin := communityPoolCoins.AmountOf(bondDenom)
+
+	if bondDenomCoin.IsZero() {
+		ctx.Logger().Info("No bond denom funds in community pool to convert")
+		return nil
+	}
+
+	// Calculate 90% of funds to convert
+	amountToConvert := bondDenomCoin.Mul(sdk.NewDecWithPrec(90, 2))
+	coinToConvert := sdk.NewCoin(bondDenom, amountToConvert.TruncateInt())
+
+	// First, distribute from community pool to photon module account
+	moduleAddr := keepers.AccountKeeper.GetModuleAddress(photontypes.ModuleName)
+	err := keepers.DistrKeeper.DistributeFromFeePool(ctx, sdk.NewCoins(coinToConvert), moduleAddr)
+	if err != nil {
+		return fmt.Errorf("failed to distribute from community pool: %w", err)
+	}
+
+	bondDenomSupply := keepers.BankKeeper.GetSupply(ctx, bondDenom).Amount.ToLegacyDec()
+	uphotonSupply := keepers.BankKeeper.GetSupply(ctx, photontypes.Denom).Amount.ToLegacyDec()
+	conversionRate := keepers.PhotonKeeper.PhotonConversionRate(ctx, bondDenomSupply, uphotonSupply)
+
+	// Calculate photons to mint
+	photonAmtToMint := coinToConvert.Amount.ToLegacyDec().Mul(conversionRate).TruncateInt()
+	photonToMint := sdk.NewCoin(photontypes.Denom, photonAmtToMint)
+
+	// Mint photons
+	err = keepers.BankKeeper.MintCoins(ctx, photontypes.ModuleName, sdk.NewCoins(photonToMint))
+	if err != nil {
+		return fmt.Errorf("failed to mint photons: %w", err)
+	}
+
+	// Burn the bond denom coins
+	err = keepers.BankKeeper.BurnCoins(ctx, photontypes.ModuleName, sdk.NewCoins(coinToConvert))
+	if err != nil {
+		return fmt.Errorf("failed to burn bond denom coins: %w", err)
+	}
+
+	// Send minted photons back to community pool
+	err = keepers.DistrKeeper.FundCommunityPool(ctx, sdk.NewCoins(photonToMint), moduleAddr)
+	if err != nil {
+		return fmt.Errorf("failed to fund community pool with photons: %w", err)
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			"convert_community_pool_to_photon",
+			sdk.NewAttribute("bond_denom_converted", coinToConvert.String()),
+			sdk.NewAttribute("photons_minted", photonToMint.String()),
+			sdk.NewAttribute("conversion_rate", conversionRate.String()),
+		),
+	)
+
+	return nil
+}
+
+// convertTreasuryDAOFundsToPhoton converts 90% of the treasury DAO's bond denom funds to photons
+func convertTreasuryDAOFundsToPhoton(ctx sdk.Context, keepers *keepers.AppKeepers, bondDenom string, treasuryAddr string) error {
+	treasuryAccAddr, err := sdk.AccAddressFromBech32(treasuryAddr)
+	if err != nil {
+		return fmt.Errorf("invalid treasury DAO address: %w", err)
+	}
+
+	// Get treasury balance
+	balance := keepers.BankKeeper.GetBalance(ctx, treasuryAccAddr, bondDenom)
+
+	if balance.IsZero() {
+		ctx.Logger().Info("No bond denom funds in treasury DAO to convert")
+		return nil
+	}
+
+	// Calculate 90% of funds
+	amountToConvert := balance.Amount.ToLegacyDec().Mul(sdk.NewDecWithPrec(90, 2)).TruncateInt()
+	coinToConvert := sdk.NewCoin(bondDenom, amountToConvert)
+
+	// Send bond denom to photon module account for burning
+	err = keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, treasuryAccAddr, photontypes.ModuleName, sdk.NewCoins(coinToConvert))
+	if err != nil {
+		return fmt.Errorf("failed to send coins from treasury to module: %w", err)
+	}
+
+	bondDenomSupply := keepers.BankKeeper.GetSupply(ctx, bondDenom).Amount.ToLegacyDec()
+	uphotonSupply := keepers.BankKeeper.GetSupply(ctx, photontypes.Denom).Amount.ToLegacyDec()
+	conversionRate := keepers.PhotonKeeper.PhotonConversionRate(ctx, bondDenomSupply, uphotonSupply)
+
+	// Calculate photons to mint
+	photonAmtToMint := coinToConvert.Amount.ToLegacyDec().Mul(conversionRate).RoundInt()
+	photonToMint := sdk.NewCoin(photontypes.Denom, photonAmtToMint)
+
+	// Mint photons
+	err = keepers.BankKeeper.MintCoins(ctx, photontypes.ModuleName, sdk.NewCoins(photonToMint))
+	if err != nil {
+		return fmt.Errorf("failed to mint photons: %w", err)
+	}
+
+	// Burn the bond denom coins
+	err = keepers.BankKeeper.BurnCoins(ctx, photontypes.ModuleName, sdk.NewCoins(coinToConvert))
+	if err != nil {
+		return fmt.Errorf("failed to burn bond denom coins: %w", err)
+	}
+
+	// Send minted photons back to treasury
+	err = keepers.BankKeeper.SendCoinsFromModuleToAccount(ctx, photontypes.ModuleName, treasuryAccAddr, sdk.NewCoins(photonToMint))
+	if err != nil {
+		return fmt.Errorf("failed to send photons to treasury: %w", err)
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			"convert_treasury_to_photon",
+			sdk.NewAttribute("bond_denom_converted", coinToConvert.String()),
+			sdk.NewAttribute("photons_minted", photonToMint.String()),
+			sdk.NewAttribute("conversion_rate", conversionRate.String()),
+		),
+	)
+
 	return nil
 }

--- a/contrib/localnet/proposal_upgrade.json
+++ b/contrib/localnet/proposal_upgrade.json
@@ -4,7 +4,7 @@
    "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
    "authority": "atone10d07y265gmmuvt4z0w9aw880jnsr700j5z0zqt",
    "plan": {
-    "name": "v2",
+    "name": "v3",
     "time": "0001-01-01T00:00:00Z",
     "height": "80",
     "info": "",
@@ -14,6 +14,6 @@
  ],
  "metadata": "ipfs://CID",
  "deposit": "512000000uatone",
- "title": "v2",
- "summary": "v2"
+ "title": "v3",
+ "summary": "v3"
 }

--- a/x/photon/keeper/grpc_query.go
+++ b/x/photon/keeper/grpc_query.go
@@ -29,7 +29,7 @@ func (k Keeper) ConversionRate(goCtx context.Context, req *types.QueryConversion
 		bondDenom          = k.stakingKeeper.BondDenom(ctx)
 		stakingDenomSupply = k.bankKeeper.GetSupply(ctx, bondDenom).Amount.ToLegacyDec()
 		uphotonSupply      = k.bankKeeper.GetSupply(ctx, types.Denom).Amount.ToLegacyDec()
-		cr                 = k.conversionRate(ctx, stakingDenomSupply, uphotonSupply)
+		cr                 = k.PhotonConversionRate(ctx, stakingDenomSupply, uphotonSupply)
 	)
 	return &types.QueryConversionRateResponse{ConversionRate: cr.String()}, nil
 }

--- a/x/photon/keeper/keeper.go
+++ b/x/photon/keeper/keeper.go
@@ -44,9 +44,9 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-// conversionRate returns the conversion rate for converting bond denom to
+// PhotonConversionRate returns the conversion rate for converting bond denom to
 // photon.
-func (k Keeper) conversionRate(_ sdk.Context, bondDenomSupply, uphotonSupply sdk.Dec) sdk.Dec {
+func (k Keeper) PhotonConversionRate(_ sdk.Context, bondDenomSupply, uphotonSupply sdk.Dec) sdk.Dec {
 	remainMintableUphotons := sdk.NewDec(types.MaxSupply).Sub(uphotonSupply)
 	if remainMintableUphotons.IsNegative() {
 		// If for any reason the max supply is exceeded, avoid returning a negative number

--- a/x/photon/keeper/msg_server.go
+++ b/x/photon/keeper/msg_server.go
@@ -40,7 +40,7 @@ func (k msgServer) MintPhoton(goCtx context.Context, msg *types.MsgMintPhoton) (
 	var (
 		bondDenomSupply = k.bankKeeper.GetSupply(ctx, bondDenom).Amount.ToLegacyDec()
 		uphotonSupply   = k.bankKeeper.GetSupply(ctx, types.Denom).Amount.ToLegacyDec()
-		conversionRate  = k.conversionRate(ctx, bondDenomSupply, uphotonSupply)
+		conversionRate  = k.PhotonConversionRate(ctx, bondDenomSupply, uphotonSupply)
 		bondDenomToBurn = msg.Amount
 		uphotonToMint   = bondDenomToBurn.Amount.ToLegacyDec().Mul(conversionRate).RoundInt()
 	)

--- a/x/photon/keeper/resolver.go
+++ b/x/photon/keeper/resolver.go
@@ -18,7 +18,7 @@ func (k Keeper) ConvertToDenom(ctx sdk.Context, coin sdk.DecCoin, denom string) 
 		// use the conversion rate to convert bond denom to photon
 		bondDenomSupply := k.bankKeeper.GetSupply(ctx, denom).Amount.ToLegacyDec()
 		uphotonSupply := k.bankKeeper.GetSupply(ctx, types.Denom).Amount.ToLegacyDec()
-		conversionRate := k.conversionRate(ctx, bondDenomSupply, uphotonSupply)
+		conversionRate := k.PhotonConversionRate(ctx, bondDenomSupply, uphotonSupply)
 
 		// convert bond denom to photon
 		amount := coin.Amount.Quo(conversionRate)


### PR DESCRIPTION
As the title suggests, this PR creates v3/upgrade code to mint photon using 90% of atone funds from both the community pool as well as the designated address of the Treasury DAO