### PR TITLE
fix(gov): ensure that quorum caps are consistent (max >= min)

### DIFF
--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -252,6 +252,16 @@ func (p Params) ValidateBasic() error {
 		}
 	}
 
+	if sdk.MustNewDecFromStr(p.QuorumRange.Max).LT(sdk.MustNewDecFromStr(p.QuorumRange.Min)) {
+		return fmt.Errorf("quorum range max must be greater than or equal to min: %s", p.QuorumRange)
+	}
+	if sdk.MustNewDecFromStr(p.ConstitutionAmendmentQuorumRange.Max).LT(sdk.MustNewDecFromStr(p.ConstitutionAmendmentQuorumRange.Min)) {
+		return fmt.Errorf("constitution amendment quorum range max must be greater than or equal to min: %s", p.ConstitutionAmendmentQuorumRange)
+	}
+	if sdk.MustNewDecFromStr(p.LawQuorumRange.Max).LT(sdk.MustNewDecFromStr(p.LawQuorumRange.Min)) {
+		return fmt.Errorf("law quorum range max must be greater than or equal to min: %s", p.LawQuorumRange)
+	}
+
 	threshold, err := sdk.NewDecFromStr(p.Threshold)
 	if err != nil {
 		return fmt.Errorf("invalid threshold string: %w", err)


### PR DESCRIPTION
Add validation for quorum caps to ensure that max value is greater or equal than min value