### PR TITLE
fix(feemarket): prevent setting `TargetBlockUtilization` to 0

### DIFF
--- a/x/feemarket/types/params.go
+++ b/x/feemarket/types/params.go
@@ -56,8 +56,8 @@ func (p *Params) ValidateBasic() error {
 		return fmt.Errorf("min base gas price cannot be nil and must be greater than or equal to zero")
 	}
 
-	if p.TargetBlockUtilization.IsNil() || p.TargetBlockUtilization.IsNegative() || p.TargetBlockUtilization.GT(math.LegacyOneDec()) {
-		return fmt.Errorf("target block utilization must be between [0, 1]")
+	if p.TargetBlockUtilization.IsNil() || !p.TargetBlockUtilization.IsPositive() || p.TargetBlockUtilization.GT(math.LegacyOneDec()) {
+		return fmt.Errorf("target block utilization must be between (0, 1]")
 	}
 
 	if p.MaxLearningRate.IsNil() || p.MinLearningRate.IsNegative() {

--- a/x/feemarket/types/params_test.go
+++ b/x/feemarket/types/params_test.go
@@ -180,6 +180,19 @@ func TestParams(t *testing.T) {
 			expectedErr: true,
 		},
 		{
+			name: "target block utilization is zero",
+			p: types.Params{
+				Window:                 1,
+				Alpha:                  math.LegacyMustNewDecFromStr("0.1"),
+				Beta:                   math.LegacyMustNewDecFromStr("0.1"),
+				Gamma:                  math.LegacyMustNewDecFromStr("0.1"),
+				MinBaseGasPrice:        math.LegacyMustNewDecFromStr("1.0"),
+				TargetBlockUtilization: math.LegacyMustNewDecFromStr("0"),
+				FeeDenom:               types.DefaultFeeDenom,
+			},
+			expectedErr: true,
+		},
+		{
 			name: "target block utilization is greater than 1",
 			p: types.Params{
 				Window:                 1,


### PR DESCRIPTION
The `TargetBlockUtilization` parameter should be prevented from being set to 0. There are other ways to disable the feemarket making this one sort of redundant.

Moreover, this would prevent a division by 0 panic (caught by the error manager, so no chain halt, but still annoying)