### PR TITLE
chore(gov): gracefully handle failure to unpack a `sdk.Msg` in `ProposalKinds`

### DIFF
--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -335,6 +335,11 @@ func (k Keeper) ProposalKinds(p v1.Proposal) v1.ProposalKinds {
 			default:
 				kinds |= v1.ProposalKindAny
 			}
+		} else {
+			// If we can't unpack the message, it's likely a broken proposal.
+			// although almost impossible, we still want to handle it gracefully.
+			// We assume that the proposal is of any kind.
+			kinds |= v1.ProposalKindAny
 		}
 	}
 	return kinds


### PR DESCRIPTION
Although this is almost impossible in realistic scenarios, we still want to catch potential failures of `cdc.UnpackAny` for an `sdk.Msg` in a proposal when calling `ProposalKinds`.
Therefore, an else statement catches this failure and assumes the default `v1.ProposalKindAny`.