### PR TITLE
fix(gov/simulation): return zero if max-min <= 0 for certain generated params

### DIFF
--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -126,6 +126,9 @@ func GenDepositParamsMinDepositSensitivityTargetDistance(r *rand.Rand) uint64 {
 
 // GenDepositParamsMinDepositChangeRatio returns randomized DepositParamsMinDepositChangeRatio
 func GenDepositParamsMinDepositChangeRatio(r *rand.Rand, max, prec int) sdk.Dec {
+	if max <= 0 {
+		return sdk.ZeroDec()
+	}
 	return sdk.NewDecWithPrec(int64(simulation.RandIntBetween(r, 0, max)), int64(prec))
 }
 
@@ -146,6 +149,9 @@ func GenDepositParamsMinInitialDepositSensitivityTargetDistance(r *rand.Rand) ui
 
 // GenDepositParamsMinInitialDepositChangeRatio returns randomized DepositParamsMinInitialDepositChangeRatio
 func GenDepositParamsMinInitialDepositChangeRatio(r *rand.Rand, max, prec int) sdk.Dec {
+	if max <= 0 {
+		return sdk.ZeroDec()
+	}
 	return sdk.NewDecWithPrec(int64(simulation.RandIntBetween(r, 0, max)), int64(prec))
 }
 


### PR DESCRIPTION
The failed run for PR #167 for the nondeterminism test (see https://github.com/atomone-hub/atomone/actions/runs/16119695430/job/45482097081?pr=167)

made me realize we need to avoid to have `n <= 0` for `Intn()` (called by `RandIntBetween`) since this triggers a panic.
This can happen if max ends up being == min (== 0) which may very well happen for certain generated genesis parameters in simulation that have parametric maximum.

Therefore, I added an if statement that returns a `sdk.ZeroDec` value in case this happen, avoiding failure.