### PR TITLE
fix(gov): fix CLI command `init genesis` param generation for dynamic deposit

### DIFF
--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -450,7 +450,6 @@ func (s *IntegrationTestSuite) testGovDynamicQuorum() {
 		s.Require().Equal(quorumsAfter.Quorum, quorums.Quorum)
 		s.Require().Equal(quorumsAfter.LawQuorum, quorums.LawQuorum)
 	})
-
 }
 
 func (s *IntegrationTestSuite) submitLegacyGovProposal(chainAAPIEndpoint, sender string, proposalID int, proposalType string, submitFlags []string, depositFlags []string, voteFlags []string, voteCommand string, withDeposit bool) {

--- a/x/gov/keeper/min_deposit_test.go
+++ b/x/gov/keeper/min_deposit_test.go
@@ -31,7 +31,7 @@ func TestActiveProposalNumber(t *testing.T) {
 
 func TestGetMinDeposit(t *testing.T) {
 	var (
-		minDepositFloor   = v1.DefaultMinDepositFloor
+		minDepositFloor   = v1.GetDefaultMinDepositFloor()
 		minDepositFloorX2 = minDepositFloor.MulInt(sdk.NewInt(2))
 		updatePeriod      = v1.DefaultMinDepositUpdatePeriod
 		N                 = v1.DefaultTargetActiveProposals

--- a/x/gov/keeper/min_initial_deposit_test.go
+++ b/x/gov/keeper/min_initial_deposit_test.go
@@ -31,7 +31,7 @@ func TestInactiveProposalNumber(t *testing.T) {
 
 func TestGetMinInitialDeposit(t *testing.T) {
 	var (
-		minInitialDepositFloor   = v1.DefaultMinInitialDepositFloor
+		minInitialDepositFloor   = v1.GetDefaultMinInitialDepositFloor()
 		minInitialDepositFloorX2 = minInitialDepositFloor.MulInt(sdk.NewInt(2))
 		updatePeriod             = v1.DefaultMinInitialDepositUpdatePeriod
 		N                        = v1.DefaultTargetProposalsInDepositPeriod

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -173,7 +173,7 @@ func (suite *KeeperTestSuite) TestVoteReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinInitialDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -272,7 +272,7 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		v1.DefaultMinDepositFloor,
+		v1.GetDefaultMinDepositFloor(),
 		proposer.String(),
 		"",
 		"Proposal",
@@ -293,7 +293,7 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinInitialDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -343,7 +343,7 @@ func (suite *KeeperTestSuite) TestVoteWeightedReq() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinDepositFloor,
+					v1.GetDefaultMinDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -392,7 +392,7 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		v1.DefaultMinInitialDepositFloor,
+		v1.GetDefaultMinInitialDepositFloor(),
 		proposer.String(),
 		"",
 		"Proposal",
@@ -425,7 +425,7 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   v1.DefaultMinDepositFloor,
+			deposit:   v1.GetDefaultMinDepositFloor(),
 			expErr:    false,
 			options:   v1.NewNonSplitVoteOption(v1.OptionYes),
 		},
@@ -437,7 +437,7 @@ func (suite *KeeperTestSuite) TestDepositReq() {
 				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   v1.DefaultMinDepositFloor.Add(sdk.NewCoin("ibc/badcoin", sdk.NewInt(1000))),
+			deposit:   v1.GetDefaultMinDepositFloor().Add(sdk.NewCoin("ibc/badcoin", sdk.NewInt(1000))),
 			expErr:    true,
 			options:   v1.NewNonSplitVoteOption(v1.OptionYes),
 		},
@@ -472,7 +472,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 			preRun: func() (*v1beta1.MsgSubmitProposal, error) {
 				return v1beta1.NewMsgSubmitProposal(
 					v1beta1.NewTextProposal("test", "I am test"),
-					v1.DefaultMinInitialDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer,
 				)
 			},
@@ -482,7 +482,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgSubmitProposal() {
 			preRun: func() (*v1beta1.MsgSubmitProposal, error) {
 				return v1beta1.NewMsgSubmitProposal(
 					v1beta1.NewTextProposal("test", "I am test"),
-					v1.DefaultMinDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer,
 				)
 			},
@@ -547,7 +547,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgVote() {
 				bankMsg.Amount = suite.govKeeper.GetMinDeposit(suite.ctx)
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinInitialDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -634,7 +634,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		v1.DefaultMinDepositFloor,
+		v1.GetDefaultMinDepositFloor(),
 		proposer.String(),
 		"",
 		"Proposal",
@@ -660,7 +660,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinInitialDepositFloor,
+					v1.GetDefaultMinInitialDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -693,7 +693,7 @@ func (suite *KeeperTestSuite) TestLegacyVoteWeighted() {
 			preRun: func() uint64 {
 				msg, err := v1.NewMsgSubmitProposal(
 					[]sdk.Msg{bankMsg},
-					v1.DefaultMinDepositFloor,
+					v1.GetDefaultMinDepositFloor(),
 					proposer.String(),
 					"",
 					"Proposal",
@@ -744,7 +744,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 
 	msg, err := v1.NewMsgSubmitProposal(
 		[]sdk.Msg{bankMsg},
-		v1.DefaultMinInitialDepositFloor,
+		v1.GetDefaultMinInitialDepositFloor(),
 		proposer.String(),
 		"",
 		"Proposal",
@@ -777,7 +777,7 @@ func (suite *KeeperTestSuite) TestLegacyMsgDeposit() {
 				return res.ProposalId
 			},
 			depositor: proposer,
-			deposit:   v1.DefaultMinDepositFloor,
+			deposit:   v1.GetDefaultMinDepositFloor(),
 			expErr:    false,
 			options:   v1beta1.NewNonSplitVoteOption(v1beta1.OptionYes),
 		},

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -61,7 +61,7 @@ var (
 	DefaultMinDepositIncreaseRatio                                          = sdk.NewDecWithPrec(5, 2)
 	DefaultMinDepositDecreaseRatio                                          = sdk.NewDecWithPrec(25, 3)
 	DefaultTargetActiveProposals                              uint64        = 2
-	DefaultMinInitialDepositFloorAmount                       sdk.Int       = sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()
+	DefaultMinInitialDepositFloorAmount                       math.Int      = sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()
 	DefaultMinInitialDepositUpdatePeriod                      time.Duration = time.Hour * 24
 	DefaultMinInitialDepositDecreaseSensitivityTargetDistance uint64        = 2
 	DefaultMinInitialDepositIncreaseRatio                                   = sdk.NewDecWithPrec(1, 2)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -165,9 +165,6 @@ func NewParams(
 
 // DefaultParams returns the default governance params
 func DefaultParams() Params {
-	DefaultMinDepositFloor := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens))
-	DefaultMinInitialDepositFloor := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()))
-
 	return NewParams(
 		// sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens)),
 		DefaultDepositPeriod,
@@ -182,13 +179,13 @@ func DefaultParams() Params {
 		DefaultQuorumTimeout,
 		DefaultMaxVotingPeriodExtension,
 		DefaultQuorumCheckCount,
-		DefaultMinDepositFloor,
+		GetDefaultMinDepositFloor(),
 		DefaultMinDepositUpdatePeriod,
 		DefaultMinDepositDecreaseSensitivityTargetDistance,
 		DefaultMinDepositIncreaseRatio.String(),
 		DefaultMinDepositDecreaseRatio.String(),
 		DefaultTargetActiveProposals,
-		DefaultMinInitialDepositFloor,
+		GetDefaultMinInitialDepositFloor(),
 		DefaultMinInitialDepositUpdatePeriod,
 		DefaultMinInitialDepositDecreaseSensitivityTargetDistance,
 		DefaultMinInitialDepositIncreaseRatio.String(),
@@ -481,4 +478,16 @@ func (p Params) ValidateBasic() error {
 	}
 
 	return nil
+}
+
+// GetDefaultMinDepositFloor returns the default minimum deposit floor
+// required so the correct `sdk.DefaultBondDenom` is used.
+func GetDefaultMinDepositFloor() sdk.Coins {
+	return sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens))
+}
+
+// GetDefaultMinInitialDepositFloor returns the default minimum initial deposit floor
+// required so the correct `sdk.DefaultBondDenom` is used.
+func GetDefaultMinInitialDepositFloor() sdk.Coins {
+	return sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinInitialDepositFloorAmount))
 }

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -56,13 +56,12 @@ var (
 	DefaultQuorumTimeout                                      time.Duration = DefaultVotingPeriod - (time.Hour * 24 * 1) // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
 	DefaultMaxVotingPeriodExtension                           time.Duration = DefaultVotingPeriod - DefaultQuorumTimeout // disabled by default (DefaultQuorumCheckCount must be set to a non-zero value to enable)
 	DefaultQuorumCheckCount                                   uint64        = 0                                          // disabled by default (0 means no check)
-	DefaultMinDepositFloor                                    sdk.Coins     = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens))
 	DefaultMinDepositUpdatePeriod                             time.Duration = time.Hour * 24 * 7
 	DefaultMinDepositDecreaseSensitivityTargetDistance        uint64        = 2
 	DefaultMinDepositIncreaseRatio                                          = sdk.NewDecWithPrec(5, 2)
 	DefaultMinDepositDecreaseRatio                                          = sdk.NewDecWithPrec(25, 3)
 	DefaultTargetActiveProposals                              uint64        = 2
-	DefaultMinInitialDepositFloor                             sdk.Coins     = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()))
+	DefaultMinInitialDepositFloorAmount                       sdk.Int       = sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()
 	DefaultMinInitialDepositUpdatePeriod                      time.Duration = time.Hour * 24
 	DefaultMinInitialDepositDecreaseSensitivityTargetDistance uint64        = 2
 	DefaultMinInitialDepositIncreaseRatio                                   = sdk.NewDecWithPrec(1, 2)
@@ -166,6 +165,9 @@ func NewParams(
 
 // DefaultParams returns the default governance params
 func DefaultParams() Params {
+	DefaultMinDepositFloor := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens))
+	DefaultMinInitialDepositFloor := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewDecWithPrec(1, 2).MulInt(DefaultMinDepositTokens).TruncateInt()))
+
 	return NewParams(
 		// sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, DefaultMinDepositTokens)),
 		DefaultDepositPeriod,


### PR DESCRIPTION
This PR fixes the generation of params for the dynamic deposit in `x/gov` when using the CLI command `init genesis` if another denom is passed with the flag `--default-denom`.

The correct denom is now used instead of always picking the default one (`stake`) regardless.