### PR TITLE
Fixed dynamicfee gas price change e2e test

### DIFF
--- a/tests/e2e/e2e_dynamicfee_test.go
+++ b/tests/e2e/e2e_dynamicfee_test.go
@@ -104,11 +104,5 @@ func (s *IntegrationTestSuite) testDynamicfeeGasPriceChange() {
 		s.Require().True(newFee.GT(oldFee),
 			"Expected new Fee (%s) higher than old fee (%s)",
 			newFee, oldFee)
-		oldLearningRate := StateBeforeMultisendTx.State.LearningRate
-		newLearningRate := StateAfterMultisendTx.State.LearningRate
-
-		s.Require().True(newLearningRate.GT(oldLearningRate),
-			"Expected newLearningRate (%s) higher than currentLearningRate (%s)",
-			newLearningRate, oldLearningRate)
 	})
 }

--- a/tests/e2e/e2e_dynamicfee_test.go
+++ b/tests/e2e/e2e_dynamicfee_test.go
@@ -2,11 +2,8 @@ package e2e
 
 import (
 	"fmt"
-	"strconv"
-	"time"
-
-	dynamicfeetypes "github.com/atomone-hub/atomone/x/dynamicfee/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"strconv"
 )
 
 func (s *IntegrationTestSuite) testDynamicfeeQuery() {
@@ -79,7 +76,6 @@ func (s *IntegrationTestSuite) testDynamicfeeGasPriceChange() {
 			valIdx        = 0
 			chainEndpoint = fmt.Sprintf("http://%s", s.valResources[c.id][valIdx].GetHostPort("1317/tcp"))
 		)
-		params := s.queryDynamicfeeParams(chainEndpoint)
 		// define one sender
 		sender, _ := c.genesisAccounts[0].keyInfo.GetAddress()
 		// Initialize array of recipients account
@@ -97,17 +93,7 @@ func (s *IntegrationTestSuite) testDynamicfeeGasPriceChange() {
 			}
 		}
 
-		// wait until the current LR is less than max LR
-		var StateBeforeMultisendTx dynamicfeetypes.StateResponse
-		s.Require().Eventually(
-			func() bool {
-				StateBeforeMultisendTx = s.queryDynamicfeeState(chainEndpoint)
-				return StateBeforeMultisendTx.State.LearningRate.LT(params.Params.MaxLearningRate)
-			},
-			10*time.Second,
-			time.Second,
-		)
-
+		StateBeforeMultisendTx := s.queryDynamicfeeState(chainEndpoint)
 		txHeight := s.execBankMultiSend(s.chainA, valIdx, sender.String(),
 			destAccountsMultisend, tokenAmount.String(), false)
 		StateAfterMultisendTx := s.queryDynamicfeeStateAtHeight(chainEndpoint, strconv.Itoa(txHeight))


### PR DESCRIPTION
The gas price change e2e test for the  `dynamicfee` module  has a loop that waits until the value of the learning rate goes below the maximum learning rate.

This loop is incorrect, as the learning rate will increase by waiting (average block utilization goes to 0, which is far from the target block utilization, hence additive increase is used to update the learning rate).

This check was not crucial to the test - that only verifies that there is a gas price increases after a big enough transaction - therefore it can be removed.
