### PR TITLE
refactor(swagger): use go:embed instead of statik for UI assets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
   timeout: 5m
   skip-dirs:
     - tests/
-    - client/docs/statik
 
 linters:
   disable-all: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### DEPENDENCIES
 
+- Remove `statik` dependency in favor of `go:embed` for swagger UI assets [#193](https://github.com/atomone-hub/atomone/pull/193)
+
 ### FEATURES
 
 - Add upgrade code to mint photon from 50% of bond denom funds of Community Pool and 90% of Treasury DAO address [#157](https://github.com/atomone-hub/atomone/pull/157) [#189](https://github.com/atomone-hub/atomone/pull/189)

--- a/Makefile
+++ b/Makefile
@@ -250,19 +250,9 @@ format: lint-fix
 		-not -name "*.pb.go" \
 		-not -name "*.pb.gw.go" \
 		-not -name "*.pulsar.go" \
-		-not -path "*client/docs/statik*" \
 		| xargs $(rundep) mvdan.cc/gofumpt -w -l
 
 .PHONY: format lint lint-fix
-
-###############################################################################
-###                              Documentation                              ###
-###############################################################################
-
-update-swagger-docs: proto-swagger-gen
-	$(rundep) github.com/rakyll/statik -ns atomone -src=client/docs/swagger-ui -dest=client/docs -f -m
-
-.PHONY: update-swagger-docs
 
 ###############################################################################
 ###                                Localnet                                 ###

--- a/app/app.go
+++ b/app/app.go
@@ -3,16 +3,13 @@ package atomone
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/gorilla/mux"
-	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
-
-	// unnamed import of statik for swagger UI support
-	_ "github.com/atomone-hub/atomone/client/docs/statik"
 
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -51,6 +48,7 @@ import (
 	"github.com/atomone-hub/atomone/app/params"
 	"github.com/atomone-hub/atomone/app/upgrades"
 	v3 "github.com/atomone-hub/atomone/app/upgrades/v3"
+	"github.com/atomone-hub/atomone/client/docs"
 	atomonepost "github.com/atomone-hub/atomone/post"
 	govtypes "github.com/atomone-hub/atomone/x/gov/types"
 )
@@ -405,15 +403,13 @@ func (app *AtomOneApp) setupUpgradeHandlers() {
 
 // RegisterSwaggerAPI registers swagger route with API Server
 func RegisterSwaggerAPI(rtr *mux.Router) {
-	// NOTE(tb) the swagger fs has been registered under the `atomone` namespace
-	// (see `update-swagger-docs` in Makefile) to avoid conflicts with the legacy
-	// swagger fs registered in the default namespace.
-	statikFS, err := fs.NewWithNamespace("atomone")
+	// Use embedded filesystem for swagger UI
+	swaggerFS, err := fs.Sub(docs.SwaggerUI, "swagger-ui")
 	if err != nil {
 		panic(err)
 	}
 
-	staticServer := http.FileServer(statikFS)
+	staticServer := http.FileServer(http.FS(swaggerFS))
 	rtr.PathPrefix("/swagger/").Handler(http.StripPrefix("/swagger/", staticServer))
 }
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -3,9 +3,6 @@ package keepers
 import (
 	"os"
 
-	// unnamed import of statik for swagger UI support
-	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
-
 	"github.com/cometbft/cometbft/libs/log"
 
 	ica "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts"

--- a/client/docs/embed.go
+++ b/client/docs/embed.go
@@ -1,0 +1,8 @@
+package docs
+
+import (
+	"embed"
+)
+
+//go:embed swagger-ui/*
+var SwaggerUI embed.FS

--- a/contrib/devdeps/go.mod
+++ b/contrib/devdeps/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.56.0
 	github.com/goreleaser/goreleaser v1.25.1
-	github.com/rakyll/statik v0.1.7
 	golang.org/x/vuln v1.1.3
 	mvdan.cc/gofumpt v0.6.0
 )

--- a/contrib/devdeps/go.sum
+++ b/contrib/devdeps/go.sum
@@ -895,8 +895,6 @@ github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 h1:TCg2WBOl
 github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4lu7Gd+PU1fV2/qnDNfzT635KRSObncs=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
-github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
-github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/contrib/devdeps/tools.go
+++ b/contrib/devdeps/tools.go
@@ -15,6 +15,5 @@ import (
 	// for releases
 	_ "github.com/goreleaser/goreleaser"
 
-	_ "github.com/rakyll/statik"
 	_ "golang.org/x/vuln/cmd/govulncheck"
 )

--- a/contrib/githooks/pre-commit
+++ b/contrib/githooks/pre-commit
@@ -25,7 +25,7 @@ f_check_cmds
 if [[ $STAGED_GO_FILES != "" ]]; then
   f_echo_stderr "[pre-commit] fmt'ing staged files..."
   for file in $STAGED_GO_FILES; do
-    if [[ $file =~ vendor/ ]] || [[ $file =~ client/lcd/statik/ ]] || [[ $file =~ tests/mocks/ ]] || [[ $file =~ \.pb\.go ]]; then
+    if [[ $file =~ vendor/ ]] || [[ $file =~ tests/mocks/ ]] || [[ $file =~ \.pb\.go ]]; then
       continue
     fi
 

--- a/contrib/githooks/precommit
+++ b/contrib/githooks/precommit
@@ -25,7 +25,7 @@ f_check_cmds
 if [[ $STAGED_GO_FILES != "" ]]; then
   f_echo_stderr "[pre-commit] fmt'ing staged files..."
   for file in $STAGED_GO_FILES; do
-    if [[ $file =~ vendor/ ]] || [[ $file =~ client/lcd/statik/ ]] || [[ $file =~ tests/mocks/ ]] || [[ $file =~ \.pb\.go ]]; then
+    if [[ $file =~ vendor/ ]] || [[ $file =~ tests/mocks/ ]] || [[ $file =~ \.pb\.go ]]; then
       continue
     fi
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/manifoldco/promptui v0.9.0
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -163,6 +162,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/rakyll/statik v0.1.7 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect


### PR DESCRIPTION
## Description

Closes: NA

`go:embed` was introduced in go `v1.16`, and removes the need to use external libraries such as statik. This PR removes the direct dependeny and usage of `statik` and replaces it with the built-in `go:embed`


This is confirmed working with the lastest build from `main` when running

```shell
atomoned start --api.enable=true --api.swagger=true
```

<img width="962" height="496" alt="Screenshot 2025-07-29 at 2 42 49 PM" src="https://github.com/user-attachments/assets/4ba8c0bc-64b1-498f-8c79-e9bf4d4175c5" />


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/atomone-hub/atomone/blob/main/CONTRIBUTING.md#pr-targeting))
- [X] Provided a link to the relevant issue or specification
- [X] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Confirmed all author checklist items have been addressed
- [x] Confirmed that this PR does not change production code <!-- e.g., updating tests -->

