### PR TITLE
fix(e2e): E2E tests do not fetch dynamic deposit values

### DIFF
--- a/tests/e2e/e2e_gov_test.go
+++ b/tests/e2e/e2e_gov_test.go
@@ -49,7 +49,7 @@ func (s *IntegrationTestSuite) testGovSoftwareUpgrade() {
 			"--upgrade-info=my-info",
 		}
 
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes=0.8,no=0.1,abstain=0.1"}
 		s.submitLegacyGovProposal(chainAAPIEndpoint, sender, proposalCounter, upgradetypes.ProposalTypeSoftwareUpgrade, submitGovFlags, depositGovFlags, voteGovFlags, "weighted-vote", true)
 
@@ -100,13 +100,13 @@ func (s *IntegrationTestSuite) testGovCancelSoftwareUpgrade() {
 			fmt.Sprintf("--upgrade-height=%d", proposalHeight),
 		}
 
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitLegacyGovProposal(chainAAPIEndpoint, sender, proposalCounter, upgradetypes.ProposalTypeSoftwareUpgrade, submitGovFlags, depositGovFlags, voteGovFlags, "vote", true)
 
 		proposalCounter++
 		submitGovFlags = []string{"cancel-software-upgrade", "--title='Upgrade V1'", "--description='Software Upgrade'"}
-		depositGovFlags = []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags = []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags = []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitLegacyGovProposal(chainAAPIEndpoint, sender, proposalCounter, upgradetypes.ProposalTypeCancelSoftwareUpgrade, submitGovFlags, depositGovFlags, voteGovFlags, "vote", true)
 
@@ -141,7 +141,7 @@ func (s *IntegrationTestSuite) testGovCommunityPoolSpend() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalCommunitySpendFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "CommunityPoolSpend", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
 
@@ -183,10 +183,16 @@ func (s *IntegrationTestSuite) testGovCommunityPoolSpend() {
 		beforeRecipientBalance, err := getSpecificBalance(chainAAPIEndpoint, recipient, uatoneDenom)
 		s.Require().NoError(err)
 
+		initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+		s.Require().NoError(err)
+		initialDeposit := initialDepositResp.GetMinInitialDeposit()
+		depositResp, err := queryGovMinDeposit(chainAAPIEndpoint)
+		s.Require().NoError(err)
+		deposit := depositResp.GetMinDeposit()[0]
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalCommunitySpendFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "no"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "CommunityPoolSpend", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusRejected)
 
@@ -196,7 +202,7 @@ func (s *IntegrationTestSuite) testGovCommunityPoolSpend() {
 				afterSenderBalance, err := getSpecificBalance(chainAAPIEndpoint, sender, uatoneDenom)
 				s.Require().NoError(err)
 
-				return afterSenderBalance.Add(depositAmount).Add(initialDepositAmount).
+				return afterSenderBalance.Add(deposit).Add(initialDeposit[0]).
 					IsEqual(beforeSenderBalance)
 			},
 			10*time.Second,
@@ -233,7 +239,7 @@ func (s *IntegrationTestSuite) testGovParamChange() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalParamChangeFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "cosmos.staking.v1beta1.MsgUpdateParams", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
 
@@ -256,7 +262,7 @@ func (s *IntegrationTestSuite) testGovParamChange() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalParamChangeFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "atomone.photon.v1.MsgUpdateParams", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
 
@@ -266,7 +272,7 @@ func (s *IntegrationTestSuite) testGovParamChange() {
 		// Revert change or mint photon test will fail
 		params.Params.MintDisabled = false
 		proposalCounter++
-		depositGovFlags = []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags = []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags = []string{strconv.Itoa(proposalCounter), "yes"}
 		s.writePhotonParamChangeProposal(s.chainA, params.Params)
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "atomone.photon.v1.MsgUpdateParams", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
@@ -288,7 +294,7 @@ func (s *IntegrationTestSuite) testGovParamChange() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalParamChangeFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "atomone.dynamicfee.v1.MsgUpdateParams", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
 
@@ -310,7 +316,7 @@ func (s *IntegrationTestSuite) testGovConstitutionAmendment() {
 		// Gov tests may be run in arbitrary order, each test must increment proposalCounter to have the correct proposal id to submit and query
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalConstitutionAmendmentFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		s.submitGovProposal(chainAAPIEndpoint, sender, proposalCounter, "gov/MsgSubmitProposal", submitGovFlags, depositGovFlags, voteGovFlags, "vote", govtypesv1beta1.StatusPassed)
 
@@ -331,7 +337,7 @@ func (s *IntegrationTestSuite) testGovTextProposal() {
 		s.writeTextProposal(s.chainA)
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalTextFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		senderAddress, _ := s.chainA.validators[0].keyInfo.GetAddress()
 		sender := senderAddress.String()
@@ -355,7 +361,7 @@ func (s *IntegrationTestSuite) testGovDynamicQuorum() {
 		s.writeTextProposal(s.chainA)
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalTextFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		senderAddress, _ := s.chainA.validators[0].keyInfo.GetAddress()
 		sender := senderAddress.String()
@@ -391,7 +397,7 @@ func (s *IntegrationTestSuite) testGovDynamicQuorum() {
 		s.writeGovLawProposal(s.chainA)
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalLawFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		senderAddress, _ := s.chainA.validators[0].keyInfo.GetAddress()
 		sender := senderAddress.String()
@@ -431,7 +437,7 @@ func (s *IntegrationTestSuite) testGovDynamicQuorum() {
 		s.writeGovConstitutionAmendmentProposal(s.chainA, amendmentMsg.Amendment)
 		proposalCounter++
 		submitGovFlags := []string{configFile(proposalConstitutionAmendmentFilename)}
-		depositGovFlags := []string{strconv.Itoa(proposalCounter), depositAmount.String()}
+		depositGovFlags := []string{strconv.Itoa(proposalCounter)}
 		voteGovFlags := []string{strconv.Itoa(proposalCounter), "yes"}
 		senderAddress, _ := s.chainA.validators[0].keyInfo.GetAddress()
 		sender := senderAddress.String()
@@ -456,9 +462,16 @@ func (s *IntegrationTestSuite) submitLegacyGovProposal(chainAAPIEndpoint, sender
 	s.T().Logf("Submitting Gov Proposal: %s", proposalType)
 	// min deposit of 1000uatone is required in e2e tests, otherwise the gov antehandler causes the proposal to be dropped
 	sflags := submitFlags
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
 	if withDeposit {
-		sflags = append(sflags, "--deposit="+initialDepositAmount.String())
+		sflags = append(sflags, "--deposit="+initialDeposit[0].String())
 	}
+	deposit, err := queryGovMinDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	depositString := deposit.GetMinDeposit()[0].String()
+	depositFlags = append(depositFlags, depositString)
 	s.submitGovCommand(chainAAPIEndpoint, sender, proposalID, "submit-legacy-proposal", sflags, govtypesv1beta1.StatusDepositPeriod)
 	s.T().Logf("Depositing Gov Proposal: %s", proposalType)
 	s.submitGovCommand(chainAAPIEndpoint, sender, proposalID, "deposit", depositFlags, govtypesv1beta1.StatusVotingPeriod)
@@ -473,6 +486,10 @@ func (s *IntegrationTestSuite) submitLegacyGovProposal(chainAAPIEndpoint, sender
 func (s *IntegrationTestSuite) submitGovProposal(chainAAPIEndpoint, sender string, proposalID int, proposalType string, submitFlags []string, depositFlags []string, voteFlags []string, voteCommand string, expectedStatusAfterVote govtypesv1beta1.ProposalStatus) {
 	s.T().Logf("Submitting Gov Proposal: %s", proposalType)
 	sflags := submitFlags
+	deposit, err := queryGovMinDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	depositString := deposit.GetMinDeposit()[0].String()
+	depositFlags = append(depositFlags, depositString)
 	s.submitGovCommand(chainAAPIEndpoint, sender, proposalID, "submit-proposal", sflags, govtypesv1beta1.StatusDepositPeriod)
 	s.T().Logf("Depositing Gov Proposal: %s", proposalType)
 	s.submitGovCommand(chainAAPIEndpoint, sender, proposalID, "deposit", depositFlags, govtypesv1beta1.StatusVotingPeriod)
@@ -555,8 +572,13 @@ func (s *IntegrationTestSuite) writeStakingParamChangeProposal(c *chain, params 
 		"summary": "summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
+
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 
@@ -578,8 +600,12 @@ func (s *IntegrationTestSuite) writeDynamicfeeParamChangeProposal(c *chain, para
 		"summary": "summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 
@@ -592,8 +618,12 @@ func (s *IntegrationTestSuite) writeTextProposal(c *chain) {
 		"summary": "summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalTextFilename), []byte(propMsgBody))
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalTextFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 
@@ -616,8 +646,12 @@ func (s *IntegrationTestSuite) writePhotonParamChangeProposal(c *chain, params p
 		"summary": "summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, govModuleAddress, cdc.MustMarshalJSON(&params), initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalParamChangeFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 
@@ -641,8 +675,12 @@ func (s *IntegrationTestSuite) writeGovConstitutionAmendmentProposal(c *chain, a
 		"summary": "summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, govModuleAddress, amendment, initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalConstitutionAmendmentFilename), []byte(propMsgBody))
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, govModuleAddress, amendment, initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalConstitutionAmendmentFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 
@@ -663,8 +701,12 @@ func (s *IntegrationTestSuite) writeGovLawProposal(c *chain) {
 	 "summary": "This is the summary"
 	}
 	`
-	propMsgBody := fmt.Sprintf(template, govModuleAddress, initialDepositAmount)
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalLawFilename), []byte(propMsgBody))
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
+	propMsgBody := fmt.Sprintf(template, govModuleAddress, initialDeposit[0])
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalLawFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -752,9 +752,13 @@ func (s *IntegrationTestSuite) writeGovCommunitySpendProposal(c *chain, amount s
 		"summary": "summary"
 	}
 	`
+	chainAAPIEndpoint := fmt.Sprintf("http://%s", s.valResources[c.id][0].GetHostPort("1317/tcp"))
+	initialDepositResp, err := queryGovMinInitialDeposit(chainAAPIEndpoint)
+	s.Require().NoError(err)
+	initialDeposit := initialDepositResp.GetMinInitialDeposit()
 	propMsgBody := fmt.Sprintf(template, govModuleAddress, recipient,
-		amount.Denom, amount.Amount.String(), initialDepositAmount.String())
-	err := writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalCommunitySpendFilename), []byte(propMsgBody))
+		amount.Denom, amount.Amount.String(), initialDeposit[0].String())
+	err = writeFile(filepath.Join(c.validators[0].configDir(), "config", proposalCommunitySpendFilename), []byte(propMsgBody))
 	s.Require().NoError(err)
 }
 

--- a/tests/e2e/query_test.go
+++ b/tests/e2e/query_test.go
@@ -177,6 +177,31 @@ func queryGovProposal(endpoint string, proposalID int) (govtypesv1beta1.QueryPro
 
 	return govProposalResp, nil
 }
+func queryGovMinInitialDeposit(endpoint string) (govtypesv1.QueryMinInitialDepositResponse, error) {
+	var govMinInitialDepositResp govtypesv1.QueryMinInitialDepositResponse
+	path := fmt.Sprintf("%s/atomone/gov/v1/mininitialdeposit", endpoint)
+	body, err := httpGet(path)
+	if err != nil {
+		return govMinInitialDepositResp, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(body, &govMinInitialDepositResp); err != nil {
+		return govMinInitialDepositResp, err
+	}
+	return govMinInitialDepositResp, nil
+}
+
+func queryGovMinDeposit(endpoint string) (govtypesv1.QueryMinDepositResponse, error) {
+	var govMinDepositResp govtypesv1.QueryMinDepositResponse
+	path := fmt.Sprintf("%s/atomone/gov/v1/mindeposit", endpoint)
+	body, err := httpGet(path)
+	if err != nil {
+		return govMinDepositResp, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(body, &govMinDepositResp); err != nil {
+		return govMinDepositResp, err
+	}
+	return govMinDepositResp, nil
+}
 
 func (s *IntegrationTestSuite) queryGovQuorums(endpoint string) govtypesv1.QueryQuorumsResponse {
 	body, err := httpGet(fmt.Sprintf("%s/atomone/gov/v1/quorums", endpoint))


### PR DESCRIPTION
The dynamic deposit feature makes the required minimum initial deposit and overall deposit dynamic. E2E tests use for both a fixed amount, this can cause the tests to fail if the fixed amounts used are less than the dynamic amounts required.
 
This PR adds queries for the dynamic deposit values and uses the updated values for the e2e tests.