### PR TITLE
chore: minor format fixes

### DIFF
--- a/tests/e2e/e2e_dynamicfee_test.go
+++ b/tests/e2e/e2e_dynamicfee_test.go
@@ -2,8 +2,9 @@ package e2e
 
 import (
 	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (s *IntegrationTestSuite) testDynamicfeeQuery() {

--- a/tests/e2e/query_test.go
+++ b/tests/e2e/query_test.go
@@ -177,6 +177,7 @@ func queryGovProposal(endpoint string, proposalID int) (govtypesv1beta1.QueryPro
 
 	return govProposalResp, nil
 }
+
 func queryGovMinInitialDeposit(endpoint string) (govtypesv1.QueryMinInitialDepositResponse, error) {
 	var govMinInitialDepositResp govtypesv1.QueryMinInitialDepositResponse
 	path := fmt.Sprintf("%s/atomone/gov/v1/mininitialdeposit", endpoint)


### PR DESCRIPTION
Leftover formatting issues that I am putting in their own PR or any other branch derived from `main` will always have these if someone runs `make format`