### PR TITLE
fix(x/gov): wrong denom for min[Initial]Deposit (backport #205)

### DIFF
--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -5,6 +5,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	appparams "github.com/atomone-hub/atomone/app/params"
 	govv1 "github.com/atomone-hub/atomone/x/gov/types/v1"
 )
 
@@ -21,7 +22,9 @@ func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.Binar
 
 	defaultParams := govv1.DefaultParams()
 	params.MinDepositThrottler = defaultParams.MinDepositThrottler
+	params.MinDepositThrottler.FloorValue[0].Denom = appparams.BondDenom
 	params.MinInitialDepositThrottler = defaultParams.MinInitialDepositThrottler
+	params.MinInitialDepositThrottler.FloorValue[0].Denom = appparams.BondDenom
 	params.BurnDepositNoThreshold = defaultParams.BurnDepositNoThreshold
 
 	bz, err := cdc.Marshal(&params)

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -10,6 +10,7 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	appparams "github.com/atomone-hub/atomone/app/params"
 	"github.com/atomone-hub/atomone/x/gov"
 	v5 "github.com/atomone-hub/atomone/x/gov/migrations/v5"
 	govv1 "github.com/atomone-hub/atomone/x/gov/types/v1"
@@ -37,7 +38,11 @@ func TestMigrateStore(t *testing.T) {
 	bz = store.Get(v5.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &params))
 	require.NotNil(t, params)
-	require.Equal(t, govv1.DefaultParams().MinDepositThrottler, params.MinDepositThrottler)
-	require.Equal(t, govv1.DefaultParams().MinInitialDepositThrottler, params.MinInitialDepositThrottler)
+	expectedMinDepositThrottler := govv1.DefaultParams().MinDepositThrottler
+	expectedMinDepositThrottler.FloorValue[0].Denom = appparams.BondDenom
+	require.Equal(t, expectedMinDepositThrottler, params.MinDepositThrottler)
+	expectedMinInitialDepositThrottler := govv1.DefaultParams().MinInitialDepositThrottler
+	expectedMinInitialDepositThrottler.FloorValue[0].Denom = appparams.BondDenom
+	require.Equal(t, expectedMinInitialDepositThrottler, params.MinInitialDepositThrottler)
 	require.Equal(t, govv1.DefaultParams().BurnDepositNoThreshold, params.BurnDepositNoThreshold)
 }


### PR DESCRIPTION
The migration use the default params to feed the minDeposit and minInitialDeposit, but they are using the sdk.DefaultBondDenom which is `stake`.

The fix simply udpates the denom of each to use `uatone`.
