### PR TITLE
docs: generate key from custom entropy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,38 @@ layout: home
 
 Welcome to the documentation of the **AtomOne application: `atomone`**.
 
+## Generate a key from manual entropy generation
+
+If you don't want to rely on computer-generated randomness, you can provide
+your own entropy to generate a key. The following method ensures your private
+key's randomness comes from physical sources rather than computer algorithms.
+
+First, generate the mnenonic:
+
+```sh
+$ atomoned keys mnemonic --unsafe-entropy
+> > WARNING: Generate at least 256-bits of entropy and enter the results here:
+```
+
+Use one of the following methods to generate entropy:
+
+- **Dice**: Roll a D20 (20-sided die) exactly 42 times.
+Example: `18 7 3 12 5 19 8 2 14 11 20 1 9 15 4 13 6 17 10 16 3 8 12 19 2 7 14 5 11 18 1 20 9 4 15 13 17 6 10 16 3 11`
+
+- **Cards**: Shuffle a standard 52-card deck 20 times, then record the full
+deck order.
+Example: `AS 2H 7C KD 3S 9H QC 4D JH 10S 5C 8H AC 2D 7S KH 3C 9D QS 4H JS 10C 5D 8S AH
+
+Write the output mnenomic in a safe place, then run the following command to
+generate the key:
+
+```sh
+$ atomoned keys add <NAME> --recover
+> Enter your bip39 mnemonic
+```
+
+Copy/paste the mnemonic and you're done.
+
 ## Testing Chain Upgrade
 
 Chain upgrade is an important procedure that should be tested carefully. This


### PR DESCRIPTION
Similarly to `gnokey add mykey --entropy` [0], this section describes how to generate a key from a custom user entropy.

Since there's already a command to generate a mnemonic from a custom entropy (`keys mnemonic --unsafe-entropy`), I deemed unecessary to add a `--entropy` flag to the `keys add` command like in `gnokey`. As a result, generating a key with a custom entropy is a 2-step process, but that's probably good enough.

[0]: https://github.com/gnolang/gno/pull/4586

