### PR TITLE
chore(x/photon): clarify impossibility of division by zero in `PhotonConversionRate`

### DIFF
--- a/x/photon/keeper/keeper.go
+++ b/x/photon/keeper/keeper.go
@@ -48,11 +48,18 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 
 // PhotonConversionRate returns the conversion rate for converting bond denom to
 // photon.
+// NOTE: bondDenomSupply cannot be zero when the chain is producing blocks (thus it can never be zero).
+// This is because the only way for validators to be able to participate in block production is to have
+// staked bond denom, which therefore is locked and cannot be burned. Although this condition is logically
+// impossible, we still add a panic here to be defensive.
 func (k Keeper) PhotonConversionRate(_ context.Context, bondDenomSupply, uphotonSupply math.LegacyDec) math.LegacyDec {
 	remainMintableUphotons := math.LegacyNewDec(types.MaxSupply).Sub(uphotonSupply)
 	if remainMintableUphotons.IsNegative() {
 		// If for any reason the max supply is exceeded, avoid returning a negative number
 		return math.LegacyZeroDec()
+	}
+	if bondDenomSupply.IsZero() {
+		panic("bond denom supply cannot be zero")
 	}
 	return remainMintableUphotons.Quo(bondDenomSupply)
 }


### PR DESCRIPTION
Since I'm sick and tired of people reporting this as an issue because they did not understand the fundamental assumption that the burned token is the denom token and thus some of it need to be staked (i.e. locked) to be able to produce blocks meaning it can't go to zero literally ever, I added a clarification and a panic.
Hopefully this should discourage raising the same (wrong) issue in the future.