### PR TITLE
fix(`x/gov`): fix logic for dynamic min deposit and min initial deposit update in `UpdateParams`

### DIFF
--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -189,10 +189,15 @@ func (k msgServer) UpdateParams(goCtx context.Context, msg *v1.MsgUpdateParams) 
 	// before params change, trigger an update of the last min deposit
 	minDeposit := k.GetMinDeposit(ctx)
 	newMinDeposit := v1.GetNewMinDeposit(msg.Params.MinDepositThrottler.FloorValue, minDeposit, math.LegacyOneDec())
-	k.SetLastMinDeposit(ctx, newMinDeposit, ctx.BlockTime())
+	if !minDeposit.Equal(newMinDeposit) {
+		k.SetLastMinDeposit(ctx, newMinDeposit, ctx.BlockTime())
+	}
+
 	minInitialDeposit := k.GetMinInitialDeposit(ctx)
 	newMinInitialDeposit := v1.GetNewMinDeposit(msg.Params.MinInitialDepositThrottler.FloorValue, minInitialDeposit, math.LegacyOneDec())
-	k.SetLastMinInitialDeposit(ctx, newMinInitialDeposit, ctx.BlockTime())
+	if !minInitialDeposit.Equal(newMinInitialDeposit) {
+		k.SetLastMinInitialDeposit(ctx, newMinInitialDeposit, ctx.BlockTime())
+	}
 
 	if err := k.SetParams(ctx, msg.Params); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes an inconsistency in the update logic of `UpdateParams` for the min deposit and min initial deposit where if the floor value is set to be higher than the current value, this is not reflected in the updated amounts.