### PR TITLE
build(deps): bump to latest AtomOne SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.24.5
 
 replace (
 	cosmossdk.io/x/feegrant => cosmossdk.io/x/feegrant v0.1.1
-	cosmossdk.io/x/upgrade => github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122115547-b032334476a6
-	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122115547-b032334476a6
+	cosmossdk.io/x/upgrade => github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122222452-be13a8fd79a7
+	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122222452-be13a8fd79a7
 	github.com/cosmos/ibc-go/v10 => github.com/cosmos/ibc-go/v10 v10.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -97,10 +97,10 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122115547-b032334476a6 h1:kCPQPTR1T3/OiDLskzyeRug9vc+W1nouq9tKSHUBb54=
-github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122115547-b032334476a6/go.mod h1:sNAlodSiBn398VLBaUwAHK0S6yIIMaWPff/0Ej25OFw=
-github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122115547-b032334476a6 h1:igsxgiGfXZdIsc1rH77SsThIu7J+fjpeVRB4UAB1xAw=
-github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122115547-b032334476a6/go.mod h1:zhOx+Y5fEZF5xTjN2TF067wk5pkXgGta0dLY2zVf0RE=
+github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122222452-be13a8fd79a7 h1:W/t/oh7wFzk154cA0OY9CblaZ1x6FFUIxv++aLsuTiM=
+github.com/atomone-hub/cosmos-sdk v0.50.14-atomone.1.0.20251122222452-be13a8fd79a7/go.mod h1:sNAlodSiBn398VLBaUwAHK0S6yIIMaWPff/0Ej25OFw=
+github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122222452-be13a8fd79a7 h1:1K/ezrirkmq6PxpIBESp+IqdNDEaHgvLCKjCMNSkhMI=
+github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.1.0.20251122222452-be13a8fd79a7/go.mod h1:zhOx+Y5fEZF5xTjN2TF067wk5pkXgGta0dLY2zVf0RE=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=


### PR DESCRIPTION
Bumps AtomOne to the latest SDK version.
We are using a pseudo commit, it is mainly to check if we haven't broke any compatibility with the rest of the dependency graph.

~~As you can see a wrapper for upgrade types for IBC was needed (https://github.com/atomone-hub/cosmos-sdk/pull/29)~~ See https://github.com/atomone-hub/atomone/pull/247#issuecomment-3566646753