### PR TITLE
refactor(x/gov): disable autocli

### DIFF
--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -9,6 +9,7 @@ import (
 
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 
+	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
 
@@ -160,3 +161,8 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 { return sdkgov.ConsensusVersion }
+
+// AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
+func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
+	return nil
+}


### PR DESCRIPTION
Disable `q atomone-gov`and `tx atomone-gov`, the autocli commands aren't needed, given x/gov from AtomOne SDK already has the commands.