### PR TITLE
fix(dynamicfee): add `params.ValidateBasic` to `types\MsgUpdateParams`

### DIFF
--- a/x/dynamicfee/types/msgs.go
+++ b/x/dynamicfee/types/msgs.go
@@ -29,5 +29,5 @@ func (m *MsgUpdateParams) ValidateBasic() error {
 		return err
 	}
 
-	return nil
+	return m.Params.ValidateBasic()
 }


### PR DESCRIPTION
perform `msg.Params.ValidateBasic()` when `msg.ValidateBasic()` is invoked for `MsgUpdateParams`