### PR TITLE
fix(x/gov): add missing fields in wrapper converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Use `TruncateInt` to compute `uphotonToMint` [#250](https://github.com/atomone-hub/atomone/pull/250)
 - Fix missing ICA controller configuration [#257](https://github.com/atomone-hub/atomone/pull/257)
+- Fix wrapper converters for `x/gov` [#276](https://github.com/atomone-hub/atomone/pull/276)
 
 ### DEPENDENCIES
 

--- a/x/gov/types/v1/wrapper.go
+++ b/x/gov/types/v1/wrapper.go
@@ -154,6 +154,8 @@ func ConvertSDKParamsToAtomOne(sdkParams *sdkv1.Params) *Params {
 		QuorumRange:                      ConvertSDKQuorumRangeToAtomOne(sdkParams.QuorumRange),
 		ConstitutionAmendmentQuorumRange: ConvertSDKQuorumRangeToAtomOne(sdkParams.ConstitutionAmendmentQuorumRange),
 		LawQuorumRange:                   ConvertSDKQuorumRangeToAtomOne(sdkParams.LawQuorumRange),
+		GovernorStatusChangePeriod:       sdkParams.GovernorStatusChangePeriod,
+		MinGovernorSelfDelegation:        sdkParams.MinGovernorSelfDelegation,
 	}
 }
 
@@ -164,11 +166,12 @@ func ConvertSDKMinDepositThrottlerToAtomOne(sdkThrottler *sdkv1.MinDepositThrott
 	}
 
 	return &MinDepositThrottler{
-		FloorValue:            sdkThrottler.FloorValue,
-		UpdatePeriod:          sdkThrottler.UpdatePeriod,
-		TargetActiveProposals: sdkThrottler.TargetActiveProposals,
-		IncreaseRatio:         sdkThrottler.IncreaseRatio,
-		DecreaseRatio:         sdkThrottler.DecreaseRatio,
+		FloorValue:                        sdkThrottler.FloorValue,
+		UpdatePeriod:                      sdkThrottler.UpdatePeriod,
+		TargetActiveProposals:             sdkThrottler.TargetActiveProposals,
+		IncreaseRatio:                     sdkThrottler.IncreaseRatio,
+		DecreaseRatio:                     sdkThrottler.DecreaseRatio,
+		DecreaseSensitivityTargetDistance: sdkThrottler.DecreaseSensitivityTargetDistance,
 	}
 }
 
@@ -179,11 +182,12 @@ func ConvertSDKMinInitialDepositThrottlerToAtomOne(sdkThrottler *sdkv1.MinInitia
 	}
 
 	return &MinInitialDepositThrottler{
-		FloorValue:      sdkThrottler.FloorValue,
-		UpdatePeriod:    sdkThrottler.UpdatePeriod,
-		TargetProposals: sdkThrottler.TargetProposals,
-		IncreaseRatio:   sdkThrottler.IncreaseRatio,
-		DecreaseRatio:   sdkThrottler.DecreaseRatio,
+		FloorValue:                        sdkThrottler.FloorValue,
+		UpdatePeriod:                      sdkThrottler.UpdatePeriod,
+		TargetProposals:                   sdkThrottler.TargetProposals,
+		IncreaseRatio:                     sdkThrottler.IncreaseRatio,
+		DecreaseRatio:                     sdkThrottler.DecreaseRatio,
+		DecreaseSensitivityTargetDistance: sdkThrottler.DecreaseSensitivityTargetDistance,
 	}
 }
 
@@ -442,6 +446,8 @@ func ConvertAtomOneParamsToSDK(atomoneParams *Params) *sdkv1.Params {
 		QuorumRange:                      ConvertAtomOneQuorumRangeToSDK(atomoneParams.QuorumRange),
 		ConstitutionAmendmentQuorumRange: ConvertAtomOneQuorumRangeToSDK(atomoneParams.ConstitutionAmendmentQuorumRange),
 		LawQuorumRange:                   ConvertAtomOneQuorumRangeToSDK(atomoneParams.LawQuorumRange),
+		GovernorStatusChangePeriod:       atomoneParams.GovernorStatusChangePeriod,
+		MinGovernorSelfDelegation:        atomoneParams.MinGovernorSelfDelegation,
 	}
 }
 
@@ -452,11 +458,12 @@ func ConvertAtomOneMinDepositThrottlerToSDK(atomoneThrottler *MinDepositThrottle
 	}
 
 	return &sdkv1.MinDepositThrottler{
-		FloorValue:            atomoneThrottler.FloorValue,
-		UpdatePeriod:          atomoneThrottler.UpdatePeriod,
-		TargetActiveProposals: atomoneThrottler.TargetActiveProposals,
-		IncreaseRatio:         atomoneThrottler.IncreaseRatio,
-		DecreaseRatio:         atomoneThrottler.DecreaseRatio,
+		FloorValue:                        atomoneThrottler.FloorValue,
+		UpdatePeriod:                      atomoneThrottler.UpdatePeriod,
+		TargetActiveProposals:             atomoneThrottler.TargetActiveProposals,
+		IncreaseRatio:                     atomoneThrottler.IncreaseRatio,
+		DecreaseRatio:                     atomoneThrottler.DecreaseRatio,
+		DecreaseSensitivityTargetDistance: atomoneThrottler.DecreaseSensitivityTargetDistance,
 	}
 }
 
@@ -467,11 +474,12 @@ func ConvertAtomOneMinInitialDepositThrottlerToSDK(atomoneThrottler *MinInitialD
 	}
 
 	return &sdkv1.MinInitialDepositThrottler{
-		FloorValue:      atomoneThrottler.FloorValue,
-		UpdatePeriod:    atomoneThrottler.UpdatePeriod,
-		TargetProposals: atomoneThrottler.TargetProposals,
-		IncreaseRatio:   atomoneThrottler.IncreaseRatio,
-		DecreaseRatio:   atomoneThrottler.DecreaseRatio,
+		FloorValue:                        atomoneThrottler.FloorValue,
+		UpdatePeriod:                      atomoneThrottler.UpdatePeriod,
+		TargetProposals:                   atomoneThrottler.TargetProposals,
+		IncreaseRatio:                     atomoneThrottler.IncreaseRatio,
+		DecreaseRatio:                     atomoneThrottler.DecreaseRatio,
+		DecreaseSensitivityTargetDistance: atomoneThrottler.DecreaseSensitivityTargetDistance,
 	}
 }
 


### PR DESCRIPTION
as per the title, there were some missing fields in the converters, both in the main params as well as the deposit throttlers