### PR TITLE
fix(coredaos): fix sim error when oversight DAO cannot veto proposal

### DIFF
--- a/x/coredaos/simulation/operations.go
+++ b/x/coredaos/simulation/operations.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"errors"
 	"math/rand"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -261,7 +262,11 @@ func SimulateMsgVetoProposal(gk types.GovKeeper, sk types.StakingKeeper, ak type
 			ModuleName:    types.ModuleName,
 		}
 
-		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+		operationMsg, futureOperation, err := simulation.GenAndDeliverTxWithRandFees(txCtx)
+		if errors.Is(err, types.ErrInvalidVeto) {
+			return simtypes.NoOpMsg(types.ModuleName, TypeMsgVetoProposal, "oversight DAO cannot veto this proposal"), nil, nil
+		}
+		return operationMsg, futureOperation, err
 	}
 }
 


### PR DESCRIPTION
PR #275 needs an integration due to the fact that in simulation if the oversight DAO tries to veto a proposal it should not be able to, it errors causing the simulation to fail. This PR addresses this potential allowing the simulation to properly continue.

This PR does not need a CL entry since it's an integration of #275 