### PR TITLE
chore(gov): minor fix to governor converters in wrapper

### DIFF
--- a/x/gov/types/v1/wrapper.go
+++ b/x/gov/types/v1/wrapper.go
@@ -225,9 +225,10 @@ func ConvertSDKGovernorToAtomOne(sdkGovernor *sdkv1.Governor) *Governor {
 	}
 
 	return &Governor{
-		GovernorAddress: sdkGovernor.GovernorAddress,
-		Description:     *ConvertSDKGovernorDescriptionToAtomOne(&sdkGovernor.Description),
-		Status:          GovernorStatus(sdkGovernor.Status),
+		GovernorAddress:      sdkGovernor.GovernorAddress,
+		Description:          *ConvertSDKGovernorDescriptionToAtomOne(&sdkGovernor.Description),
+		Status:               GovernorStatus(sdkGovernor.Status),
+		LastStatusChangeTime: sdkGovernor.LastStatusChangeTime,
 	}
 }
 
@@ -556,9 +557,10 @@ func ConvertAtomOneGovernorToSDK(atomoneGovernor *Governor) *sdkv1.Governor {
 	}
 
 	return &sdkv1.Governor{
-		GovernorAddress: atomoneGovernor.GovernorAddress,
-		Description:     *ConvertAtomOneGovernorDescriptionToSDK(&atomoneGovernor.Description),
-		Status:          sdkv1.GovernorStatus(atomoneGovernor.Status),
+		GovernorAddress:      atomoneGovernor.GovernorAddress,
+		Description:          *ConvertAtomOneGovernorDescriptionToSDK(&atomoneGovernor.Description),
+		Status:               sdkv1.GovernorStatus(atomoneGovernor.Status),
+		LastStatusChangeTime: atomoneGovernor.LastStatusChangeTime,
 	}
 }
 


### PR DESCRIPTION
The `LastStatusChangeTime` field was left out of the conversion. This is a really minor issue due to the fact that the field is for internal use, but for completeness, this PR adds it to the converters.