### PR TITLE
fix: register IBC proposal types for gov Content interface

### DIFF
--- a/x/gov/types/v1beta1/codec.go
+++ b/x/gov/types/v1beta1/codec.go
@@ -48,8 +48,8 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&paramsproposal.ParameterChangeProposal{},
 		&upgradetypes.SoftwareUpgradeProposal{},       //nolint:staticcheck
 		&upgradetypes.CancelSoftwareUpgradeProposal{}, //nolint:staticcheck
-		&ibcclienttypes.ClientUpdateProposal{},        //nolint:staticcheck
-		&ibcclienttypes.UpgradeProposal{},             //nolint:staticcheck
+		&ibcclienttypes.ClientUpdateProposal{},
+		&ibcclienttypes.UpgradeProposal{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)


### PR DESCRIPTION
ibc-go v7 registers ClientUpdateProposal and UpgradeProposal against the cosmos-sdk gov v1beta1.Content interface, but AtomOne uses its own gov module with a distinct Content interface. This caused MsgExecLegacyContent to fail with "no concrete type registered" when submitting IBC client recovery proposals.

AtomOne v4 is not impacted since it ClientUpdateProposal and UpgradeProposal were replaced by other types in ibc v8 and don't require a registration against the Content interface.

Fix #281

