### PR TITLE
fix(coredaos): prevent oversight DAO to veto a `authz.MsgExec`-wrapped proposal trying to replace it

### DIFF
--- a/ante/gov_ante_utils.go
+++ b/ante/gov_ante_utils.go
@@ -35,4 +35,3 @@ func iterateMsg(cdc codec.BinaryCodec, msgs []sdk.Msg, fn func(sdk.Msg) error) e
 	}
 	return nil
 }
-

--- a/ante/gov_ante_utils.go
+++ b/ante/gov_ante_utils.go
@@ -4,7 +4,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
@@ -37,23 +36,3 @@ func iterateMsg(cdc codec.BinaryCodec, msgs []sdk.Msg, fn func(sdk.Msg) error) e
 	return nil
 }
 
-// flattenAnyMsgs recursively unpacks a list of Any-encoded messages, expanding
-// authz.MsgExec wrappers so that all leaf messages are returned in a flat
-// slice. Entries that cannot be unpacked are represented as nil — they still
-// count towards the total length, which callers use to detect bundling.
-func flattenAnyMsgs(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any) []sdk.Msg {
-	var result []sdk.Msg
-	for _, anyMsg := range anyMsgs {
-		var msg sdk.Msg
-		if err := cdc.UnpackAny(anyMsg, &msg); err != nil {
-			result = append(result, nil)
-			continue
-		}
-		if execMsg, ok := msg.(*authz.MsgExec); ok {
-			result = append(result, flattenAnyMsgs(cdc, execMsg.Msgs)...)
-		} else {
-			result = append(result, msg)
-		}
-	}
-	return result
-}

--- a/ante/gov_submit_proposal_ante.go
+++ b/ante/gov_submit_proposal_ante.go
@@ -93,7 +93,7 @@ func addressChanged(newAddr, currentAddr string) (bool, error) {
 // bundled with other messages. authz.MsgExec wrappers are expanded recursively
 // so that nested oversight-DAO changes are also detected.
 func (g GovSubmitProposalDecorator) validateProposalMessages(ctx sdk.Context, anyMsgs []*codectypes.Any) error {
-	effectiveMsgs := flattenAnyMsgs(g.cdc, anyMsgs)
+	effectiveMsgs := coredaostypes.FlattenAnyMsgs(g.cdc, anyMsgs)
 
 	// Bundling is only possible when there is more than one effective message.
 	if len(effectiveMsgs) <= 1 {

--- a/x/coredaos/keeper/msg_server.go
+++ b/x/coredaos/keeper/msg_server.go
@@ -372,29 +372,24 @@ func (ms MsgServer) VetoProposal(goCtx context.Context, msg *types.MsgVetoPropos
 	}
 
 	// Check if the proposal contains a change of the oversight DAO address.
-	// If so, vetoing the proposal would create a scenario where the current oversight DAO can prevent its own replacement
-	for _, msg := range proposal.Messages {
-		if msg.GetTypeUrl() == sdk.MsgTypeURL(&types.MsgUpdateParams{}) {
-			var updateParamsMsg types.MsgUpdateParams
-			if err := updateParamsMsg.Unmarshal(msg.GetValue()); err != nil {
-				logger.Error(
-					"failed to unmarshal MsgUpdateParams from proposal messages",
-					"proposal", proposal.Id,
-					"error", err,
-				)
+	// If so, vetoing the proposal would create a scenario where the current oversight DAO can prevent its own replacement.
+	// authz.MsgExec wrappers are expanded recursively so the check cannot be bypassed by wrapping MsgUpdateParams.
+	for _, flatMsg := range types.FlattenAnyMsgs(ms.k.cdc, proposal.Messages) {
+		updateParamsMsg, ok := flatMsg.(*types.MsgUpdateParams)
+		if !ok {
+			continue
+		}
+		proposedOversightAddr, err := sdk.AccAddressFromBech32(updateParamsMsg.Params.OversightDaoAddress)
+		// treat parse error as a change of address, not using MustAccAddressFromBech32 because address could be empty
+		if err != nil || !proposedOversightAddr.Equals(sdk.MustAccAddressFromBech32(params.OversightDaoAddress)) {
+			logger.Error(
+				"proposal contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO",
+				"proposal", proposal.Id,
+				"current_oversight_dao_address", params.OversightDaoAddress,
+				"new_oversight_dao_address", updateParamsMsg.Params.OversightDaoAddress,
+			)
 
-				return nil, err
-			}
-			if updateParamsMsg.Params.OversightDaoAddress != params.OversightDaoAddress {
-				logger.Error(
-					"proposal contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO",
-					"proposal", proposal.Id,
-					"current_oversight_dao_address", params.OversightDaoAddress,
-					"new_oversight_dao_address", updateParamsMsg.Params.OversightDaoAddress,
-				)
-
-				return nil, types.ErrInvalidVeto.Wrapf("proposal with ID %d contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO", proposal.Id)
-			}
+			return nil, types.ErrInvalidVeto.Wrapf("proposal with ID %d contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO", proposal.Id)
 		}
 	}
 

--- a/x/coredaos/keeper/msg_server_test.go
+++ b/x/coredaos/keeper/msg_server_test.go
@@ -9,9 +9,11 @@ import (
 
 	"cosmossdk.io/math"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/atomone-hub/atomone/x/coredaos/testutil"
 	"github.com/atomone-hub/atomone/x/coredaos/types"
@@ -778,6 +780,46 @@ func TestMsgServerVetoProposal(t *testing.T) {
 		Status:   govtypesv1.StatusVotingPeriod,
 		Messages: proposalWithEmptyOversightDAOMsgs,
 	}
+
+	// authz-wrapped proposals: MsgUpdateParams inside authz.MsgExec
+	govAuthority := "cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn"
+	innerChangeAny, err := codectypes.NewAnyWithValue(&types.MsgUpdateParams{
+		Authority: govAuthority,
+		Params:    types.Params{OversightDaoAddress: testAcc[2].String()},
+	})
+	require.NoError(t, err)
+	wrappedChangeMsgs, err := sdktx.SetMsgs([]sdk.Msg{&authz.MsgExec{
+		Grantee: govAuthority,
+		Msgs:    []*codectypes.Any{innerChangeAny},
+	}})
+	require.NoError(t, err)
+	proposalWithWrappedChangeOversightDAO := govtypesv1.Proposal{
+		Title:    "Test Proposal",
+		Summary:  "A proposal to change oversight DAO address wrapped in authz.MsgExec",
+		Id:       6,
+		Status:   govtypesv1.StatusVotingPeriod,
+		Messages: wrappedChangeMsgs,
+	}
+
+	// double-wrapped: MsgUpdateParams inside MsgExec inside MsgExec
+	execAny, err := codectypes.NewAnyWithValue(&authz.MsgExec{
+		Grantee: govAuthority,
+		Msgs:    []*codectypes.Any{innerChangeAny},
+	})
+	require.NoError(t, err)
+	doubleWrappedChangeMsgs, err := sdktx.SetMsgs([]sdk.Msg{&authz.MsgExec{
+		Grantee: govAuthority,
+		Msgs:    []*codectypes.Any{execAny},
+	}})
+	require.NoError(t, err)
+	proposalWithDoubleWrappedChangeOversightDAO := govtypesv1.Proposal{
+		Title:    "Test Proposal",
+		Summary:  "A proposal to change oversight DAO address double-wrapped in authz.MsgExec",
+		Id:       7,
+		Status:   govtypesv1.StatusVotingPeriod,
+		Messages: doubleWrappedChangeMsgs,
+	}
+
 	tests := []struct {
 		name            string
 		msg             *types.MsgVetoProposal
@@ -918,6 +960,30 @@ func TestMsgServerVetoProposal(t *testing.T) {
 			expectedErr: "proposal with ID 5 contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO: oversight DAO cannot veto this proposal",
 			setupMocks: func(ctx sdk.Context, m *testutil.Mocks) {
 				m.GovKeeper.EXPECT().GetProposal(ctx, uint64(5)).Return(proposalWithEmptyOversightDAO, true)
+			},
+			setOversightDAO: true,
+		},
+		{
+			name: "veto proposal with change to oversight DAO address wrapped in authz.MsgExec",
+			msg: &types.MsgVetoProposal{
+				Vetoer:     oversightDAOAcc,
+				ProposalId: 6,
+			},
+			expectedErr: "proposal with ID 6 contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO: oversight DAO cannot veto this proposal",
+			setupMocks: func(ctx sdk.Context, m *testutil.Mocks) {
+				m.GovKeeper.EXPECT().GetProposal(ctx, uint64(6)).Return(proposalWithWrappedChangeOversightDAO, true)
+			},
+			setOversightDAO: true,
+		},
+		{
+			name: "veto proposal with change to oversight DAO address double-wrapped in authz.MsgExec",
+			msg: &types.MsgVetoProposal{
+				Vetoer:     oversightDAOAcc,
+				ProposalId: 7,
+			},
+			expectedErr: "proposal with ID 7 contains a change of the oversight DAO address, vetoing it would prevent the replacement of the current oversight DAO: oversight DAO cannot veto this proposal",
+			setupMocks: func(ctx sdk.Context, m *testutil.Mocks) {
+				m.GovKeeper.EXPECT().GetProposal(ctx, uint64(7)).Return(proposalWithDoubleWrappedChangeOversightDAO, true)
 			},
 			setOversightDAO: true,
 		},

--- a/x/coredaos/testutil/keeper.go
+++ b/x/coredaos/testutil/keeper.go
@@ -15,6 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	"github.com/atomone-hub/atomone/x/coredaos/keeper"
 	"github.com/atomone-hub/atomone/x/coredaos/types"
@@ -50,6 +51,7 @@ func SetupCoredaosKeeper(t *testing.T) (
 	ctx := testCtx.Ctx.WithBlockHeader(tmproto.Header{Time: tmtime.Now()})
 	encCfg := moduletestutil.MakeTestEncodingConfig()
 	types.RegisterInterfaces(encCfg.InterfaceRegistry)
+	authz.RegisterInterfaces(encCfg.InterfaceRegistry)
 	authority := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 	return keeper.NewKeeper(encCfg.Codec, storeService, authority, m.GovKeeper, m.StakingKeeper), m, ctx
 }

--- a/x/coredaos/types/utils.go
+++ b/x/coredaos/types/utils.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+)
+
+// FlattenAnyMsgs recursively unpacks Any-encoded messages, expanding
+// authz.MsgExec wrappers so that all leaf messages are returned in a flat
+// slice. Entries that cannot be unpacked are represented as nil.
+func FlattenAnyMsgs(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any) []sdk.Msg {
+	var result []sdk.Msg
+	for _, anyMsg := range anyMsgs {
+		var msg sdk.Msg
+		if err := cdc.UnpackAny(anyMsg, &msg); err != nil {
+			result = append(result, nil)
+			continue
+		}
+		if execMsg, ok := msg.(*authz.MsgExec); ok {
+			result = append(result, FlattenAnyMsgs(cdc, execMsg.Msgs)...)
+		} else {
+			result = append(result, msg)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
This PR addresses the scenario where a proposal replacing the oversight DAO is - for some reason - wrapped in an `authz.MsgExec`. In such case it would be possible for the DAO to veto a proposal replacing it, bypassing the veto prevention mechanism.

However:
- Such proposal would be practically malformed: would require grantee==granter==authority (and in itself this is kinda weird to see, and definitely would not make sense for an honest proposer even though the proposal would be formally valid).
- There's no practical attack scenario that could make use of this inconsistency: no honest proposer wanting to replace the oversight DAO would wrap the param update in a `authz.MsgExec`; conversely, someone malicious (and it could only be the oversight DAO itself or someone affiliated) that submits such a proposal would only be able to somewhat annoy the chain governance, but the effect would be marginal (just to create a proposal, then wait some time during which others might vote on it, before vetoing it), resulting likely in the future replacement of the oversight DAO for having acted in bad faith.

The PR still fixes the code for completeness (to mirror what's done in the ante) but there's no inherent risk nor practical attack that could make use of the issue being fixed here.