### PR TITLE
chore: wire `x/epochs`

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -45,6 +45,8 @@ import (
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	epochskeeper "github.com/cosmos/cosmos-sdk/x/epochs/keeper"
+	epochstypes "github.com/cosmos/cosmos-sdk/x/epochs/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
@@ -99,6 +101,7 @@ type AppKeepers struct {
 	PhotonKeeper          *photonkeeper.Keeper
 	DynamicfeeKeeper      *dynamicfeekeeper.Keeper
 	CoreDaosKeeper        *coredaoskeeper.Keeper
+	EpochsKeeper          epochskeeper.Keeper
 
 	// Modules
 	ICAModule       ica.AppModule
@@ -215,6 +218,12 @@ func NewAppKeeper(
 		authtypes.FeeCollectorName,
 		authorityStr,
 	)
+
+	appKeepers.EpochsKeeper = epochskeeper.NewKeeper(
+		runtime.NewKVStoreService(appKeepers.keys[epochstypes.StoreKey]),
+		appCodec,
+	)
+	appKeepers.EpochsKeeper.SetHooks(appKeepers.DistrKeeper.Hooks())
 
 	appKeepers.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec,

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -16,6 +16,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	epochstypes "github.com/cosmos/cosmos-sdk/x/epochs/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -51,6 +52,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 		photontypes.StoreKey,
 		dynamicfeetypes.StoreKey,
 		coredaostypes.StoreKey,
+		epochstypes.StoreKey,
 	)
 
 	// Define transient store keys

--- a/app/modules.go
+++ b/app/modules.go
@@ -163,7 +163,6 @@ func orderBeginBlockers() []string {
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		coredaostypes.ModuleName,
-		epochstypes.ModuleName,
 	}
 }
 

--- a/app/modules.go
+++ b/app/modules.go
@@ -30,6 +30,8 @@ import (
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/epochs"
+	epochstypes "github.com/cosmos/cosmos-sdk/x/epochs/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -116,6 +118,7 @@ func appModules(
 		consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
 		dynamicfee.NewAppModule(appCodec, *app.DynamicfeeKeeper),
 		coredaos.NewAppModule(appCodec, *app.CoreDaosKeeper, app.GovKeeperWrapper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
+		epochs.NewAppModule(&app.EpochsKeeper),
 
 		app.TransferModule,
 		app.ICAModule,
@@ -141,6 +144,7 @@ func orderBeginBlockers() []string {
 		upgradetypes.ModuleName,
 		minttypes.ModuleName,
 		dynamicfeetypes.ModuleName,
+		epochstypes.ModuleName,
 		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
 		evidencetypes.ModuleName,
@@ -159,6 +163,7 @@ func orderBeginBlockers() []string {
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		coredaostypes.ModuleName,
+		epochstypes.ModuleName,
 	}
 }
 
@@ -193,6 +198,7 @@ func orderEndBlockers() []string {
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		coredaostypes.ModuleName,
+		epochstypes.ModuleName,
 	}
 }
 
@@ -226,5 +232,6 @@ func orderInitBlockers() []string {
 		consensusparamtypes.ModuleName,
 		dynamicfeetypes.ModuleName,
 		coredaostypes.ModuleName,
+		epochstypes.ModuleName,
 	}
 }

--- a/app/upgrades/v4/constants.go
+++ b/app/upgrades/v4/constants.go
@@ -5,6 +5,8 @@ import (
 
 	store "cosmossdk.io/store/types"
 
+	epochstypes "github.com/cosmos/cosmos-sdk/x/epochs/types"
+
 	"github.com/atomone-hub/atomone/app/upgrades"
 	coredaostypes "github.com/atomone-hub/atomone/x/coredaos/types"
 )
@@ -22,6 +24,7 @@ var Upgrade = upgrades.Upgrade{
 			// new module added in v4
 			coredaostypes.StoreKey,
 			icacontrollertypes.StoreKey,
+			epochstypes.StoreKey,
 			// x/gov has been added but it uses the same store key as the x/gov fork from v3
 		},
 		Deleted: []string{


### PR DESCRIPTION
Wire the `x/epochs` module, required for the nakamoto bonus added to `x/distribution`