### PR TITLE
chore(v4/upgrade): proper error checking for `collections.ErrNotFound`

### DIFF
--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -251,7 +251,7 @@ func migrateLastMinDeposit(ctx context.Context, cdc codec.Codec, govKeeper *govk
 	lastMinDeposit, err := lastMinDepositItem.Get(ctx)
 	if err != nil {
 		// If not set, skip migration
-		if err.Error() == "collections: not found" {
+		if errors.Is(err, collections.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("failed to get last min deposit: %w", err)
@@ -277,7 +277,7 @@ func migrateLastMinInitialDeposit(ctx context.Context, cdc codec.Codec, govKeepe
 	lastMinInitialDeposit, err := lastMinInitialDepositItem.Get(ctx)
 	if err != nil {
 		// If not set, skip migration
-		if err.Error() == "collections: not found" {
+		if errors.Is(err, collections.ErrNotFound) {
 			return nil
 		}
 		return fmt.Errorf("failed to get last min initial deposit: %w", err)


### PR DESCRIPTION
Fix a minor inconsistency in the error checking for the `lastMinDeposit` and `lastMinInitialDeposit` migrations where the error checking was not done properly. The errors are not triggered in a realistic scenario, so the change is essentially just to improve code quality.