### PR TITLE
fix(cli): fix broken `testnet` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add min-stake filtering for cosmos-sdk votes in the gov ante handler [#279](https://github.com/atomone-hub/atomone/pull/279)
 - Prevent the designated authority to be set as the Oversight or Steering DAO address [#314](https://github.com/atomone-hub/atomone/pull/314)
 - Oversight DAO and Steering DAO addresses cannot be the same [#309](https://github.com/atomone-hub/atomone/pull/309)
+- Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
 
 ### DEPENDENCIES
 

--- a/cmd/atomoned/cmd/testnet.go
+++ b/cmd/atomoned/cmd/testnet.go
@@ -440,7 +440,7 @@ func collectGenFiles(
 			return err
 		}
 
-		nodeAppState, err := genutil.GenAppStateFromConfig(clientCtx.Codec, clientCtx.TxConfig, nodeConfig, initCfg, appGenesis, genBalIterator, genutiltypes.DefaultMessageValidator, clientCtx.InterfaceRegistry.SigningContext().AddressCodec())
+		nodeAppState, err := genutil.GenAppStateFromConfig(clientCtx.Codec, clientCtx.TxConfig, nodeConfig, initCfg, appGenesis, genBalIterator, genutiltypes.DefaultMessageValidator, clientCtx.InterfaceRegistry.SigningContext().ValidatorAddressCodec())
 		if err != nil {
 			return err
 		}
@@ -540,7 +540,7 @@ func startTestnet(cmd *cobra.Command, args startArgs) error {
 }
 
 func NewTestNetworkFixture() network.TestFixture {
-	dir, err := os.MkdirTemp("", atomone.DefaultNodeHome)
+	dir, err := os.MkdirTemp("", filepath.Base(atomone.DefaultNodeHome))
 	if err != nil {
 		panic(fmt.Sprintf("failed creating temporary directory: %v", err))
 	}


### PR DESCRIPTION
Closes #335.

Two unrelated bugs in `cmd/atomoned/cmd/testnet.go` left both `testnet` subcommands unusable post sdk v0.50.x migration:

- `testnet init-files` passed the account address codec to `genutil.GenAppStateFromConfig`, which uses it to decode each gentx's validator operator address. This caused `hrp does not match bech32 prefix: expected 'atone' got 'atonevaloper'`. Switched to `ValidatorAddressCodec()` (matches simapp).

- `testnet start` panicked in `NewTestNetworkFixture` with `pattern contains path separator` because `atomone.DefaultNodeHome` (a full path) was being passed as the `os.MkdirTemp` pattern. Now passes `filepath.Base(atomone.DefaultNodeHome)` (resolving to `.atomone`).