### PR TITLE
fix: Two defense-in-depth GNO light client fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Oversight DAO and Steering DAO addresses cannot be the same [#309](https://github.com/atomone-hub/atomone/pull/309)
 - Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
 - Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate [#341](https://github.com/atomone-hub/atomone/pull/341)
-- Validate `10-gno` validator sets during conversion (reject negative/zero voting power, duplicate addresses, and out-of-bounds totals) to prevent forged light client updates
+- Validate `10-gno` validator sets during conversion (reject negative/zero voting power, duplicate addresses, and out-of-bounds totals) to prevent forged light client updates [#341](https://github.com/atomone-hub/atomone/pull/341)
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prevent the designated authority to be set as the Oversight or Steering DAO address [#314](https://github.com/atomone-hub/atomone/pull/314)
 - Oversight DAO and Steering DAO addresses cannot be the same [#309](https://github.com/atomone-hub/atomone/pull/309)
 - Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
+- Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Oversight DAO and Steering DAO addresses cannot be the same [#309](https://github.com/atomone-hub/atomone/pull/309)
 - Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
 - Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate
+- Validate `10-gno` validator sets during conversion (reject negative/zero voting power, duplicate addresses, and out-of-bounds totals) to prevent forged light client updates
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Prevent the designated authority to be set as the Oversight or Steering DAO address [#314](https://github.com/atomone-hub/atomone/pull/314)
 - Oversight DAO and Steering DAO addresses cannot be the same [#309](https://github.com/atomone-hub/atomone/pull/309)
 - Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
-- Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate
+- Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate [#341](https://github.com/atomone-hub/atomone/pull/341)
 - Validate `10-gno` validator sets during conversion (reject negative/zero voting power, duplicate addresses, and out-of-bounds totals) to prevent forged light client updates
 
 ### DEPENDENCIES

--- a/modules/10-gno/client_state.go
+++ b/modules/10-gno/client_state.go
@@ -1,6 +1,7 @@
 package gno
 
 import (
+	"math/bits"
 	"strings"
 	"time"
 
@@ -296,7 +297,13 @@ func verifyDelayPeriodPassed(ctx sdk.Context, store storetypes.KVStore, proofHei
 		}
 
 		currentTimestamp := uint64(ctx.BlockTime().UnixNano())
-		validTime := processedTime + delayTimePeriod
+		validTime, carry := bits.Add64(processedTime, delayTimePeriod, 0)
+		if carry != 0 {
+			// processedTime + delayTimePeriod overflows uint64; the delay can never be
+			// represented and therefore cannot be considered satisfied.
+			return errorsmod.Wrapf(ErrDelayPeriodNotPassed, "time delay period overflows uint64: processed time %d, delay %d",
+				processedTime, delayTimePeriod)
+		}
 
 		// NOTE: delay time period is inclusive, so if currentTimestamp is validTime, then we return no error
 		if currentTimestamp < validTime {
@@ -313,7 +320,14 @@ func verifyDelayPeriodPassed(ctx sdk.Context, store storetypes.KVStore, proofHei
 		}
 
 		currentHeight := clienttypes.GetSelfHeight(ctx)
-		validHeight := clienttypes.NewHeight(processedHeight.GetRevisionNumber(), processedHeight.GetRevisionHeight()+delayBlockPeriod)
+		validRevisionHeight, carry := bits.Add64(processedHeight.GetRevisionHeight(), delayBlockPeriod, 0)
+		if carry != 0 {
+			// processedHeight + delayBlockPeriod overflows uint64; the delay can never be
+			// represented and therefore cannot be considered satisfied.
+			return errorsmod.Wrapf(ErrDelayPeriodNotPassed, "block delay period overflows uint64: processed height %d, delay %d",
+				processedHeight.GetRevisionHeight(), delayBlockPeriod)
+		}
+		validHeight := clienttypes.NewHeight(processedHeight.GetRevisionNumber(), validRevisionHeight)
 
 		// NOTE: delay block period is inclusive, so if currentHeight is validHeight, then we return no error
 		if currentHeight.LT(validHeight) {

--- a/modules/10-gno/helpers.go
+++ b/modules/10-gno/helpers.go
@@ -11,8 +11,17 @@ import (
 )
 
 // ConvertToGnoValidatorSet converts a protobuf ValidatorSet to a bfttypes.ValidatorSet.
-// It returns an error if any validator has a non-ed25519 public key or if the resulting
-// validator set is nil or empty.
+// It returns an error if any validator has a non-ed25519 public key, an invalid address,
+// non-positive or out-of-bounds voting power, if any address is duplicated, if the total
+// voting power exceeds the allowed bound, or if the resulting validator set is nil or empty.
+//
+// Unlike Gno's NewValidatorSet constructor (which sorts validators by address), this function
+// preserves the input order because GetByIndex-based commit verification relies on the proto
+// validator set ordering matching the commit precommit ordering. The validation below therefore
+// replicates the safety checks performed by Gno's updateWithChangeSet/processChanges without
+// reordering the set. Skipping these checks would allow a relayer-supplied set with negative
+// voting power to produce a negative total, making the +2/3 commit threshold negative and
+// satisfiable by a single signature.
 func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, error) {
 	if valSet == nil {
 		return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "validator set is nil")
@@ -23,6 +32,8 @@ func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, err
 		Proposer:   nil,
 	}
 
+	seen := make(map[string]struct{}, len(valSet.Validators))
+	totalVotingPower := int64(0)
 	for i, val := range valSet.Validators {
 		key := val.PubKey
 		if key.GetEd25519() == nil {
@@ -32,6 +43,25 @@ func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, err
 		if err != nil {
 			return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "invalid validator address")
 		}
+		if _, ok := seen[val.Address]; ok {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "duplicate validator address %s", val.Address)
+		}
+		seen[val.Address] = struct{}{}
+
+		// Reject non-positive voting power: a real Gno validator set never contains
+		// negative- or zero-power members (zero-power entries are removed during updates).
+		// A negative power would corrupt the total and the +2/3 commit threshold.
+		if val.VotingPower <= 0 {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "validator %s has non-positive voting power %d", val.Address, val.VotingPower)
+		}
+		if val.VotingPower > bfttypes.MaxTotalVotingPower {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "validator %s voting power %d exceeds max %d", val.Address, val.VotingPower, bfttypes.MaxTotalVotingPower)
+		}
+		totalVotingPower += val.VotingPower
+		if totalVotingPower > bfttypes.MaxTotalVotingPower {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "total voting power exceeds max %d", bfttypes.MaxTotalVotingPower)
+		}
+
 		gnoValset.Validators[i] = &bfttypes.Validator{
 			Address:          address,
 			PubKey:           ed25519.PubKeyEd25519(key.GetEd25519()),

--- a/modules/10-gno/helpers_test.go
+++ b/modules/10-gno/helpers_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	bfttypes "github.com/gnolang/gno/tm2/pkg/bft/types"
+	"github.com/gnolang/gno/tm2/pkg/crypto"
+	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +61,85 @@ func TestConvertToGnoCommit_AllAbsent(t *testing.T) {
 
 	for i, pc := range gnoCommit.Precommits {
 		require.Nil(t, pc, "precommit %d should be nil for absent validator", i)
+	}
+}
+
+// TestConvertToGnoValidatorSet_RejectsMalformedSets ensures that
+// ConvertToGnoValidatorSet validates relayer-supplied validator sets the same way
+// Gno's NewValidatorSet constructor does. A set containing negative voting power must
+// be rejected: otherwise the total voting power can become negative, making the +2/3
+// commit threshold negative and satisfiable by a single signature, which would allow a
+// forged light-client update.
+func TestConvertToGnoValidatorSet_RejectsMalformedSets(t *testing.T) {
+	valA, keyA := createTestValidator(1)
+	valB, keyB := createTestValidator(10)
+	// A duplicate of valA (same address) for the duplicate-address case.
+	dupA := createTestValidatorWithKey(5, keyA)
+
+	t.Run("negative voting power", func(t *testing.T) {
+		neg := createTestValidatorWithKey(-10, keyB)
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, neg}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+
+		// Sanity check: Gno's own constructor also rejects this set.
+		require.Panics(t, func() {
+			bfttypes.NewValidatorSet([]*bfttypes.Validator{
+				toBftValidator(valA), toBftValidator(neg),
+			})
+		})
+	})
+
+	t.Run("zero voting power", func(t *testing.T) {
+		zero := createTestValidatorWithKey(0, keyB)
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, zero}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("duplicate address", func(t *testing.T) {
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, dupA}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("voting power exceeds max", func(t *testing.T) {
+		tooBig := createTestValidatorWithKey(bfttypes.MaxTotalVotingPower+1, keyB)
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{tooBig}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("total voting power exceeds max", func(t *testing.T) {
+		half := createTestValidatorWithKey(bfttypes.MaxTotalVotingPower-1, keyA)
+		half2 := createTestValidatorWithKey(bfttypes.MaxTotalVotingPower-1, keyB)
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{half, half2}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("valid set is accepted with order and total preserved", func(t *testing.T) {
+		vals, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, valB}})
+		require.NoError(t, err)
+		require.Equal(t, int64(11), vals.TotalVotingPower())
+		require.Len(t, vals.Validators, 2)
+		// Input order must be preserved (commit verification relies on index ordering).
+		require.Equal(t, valA.Address, vals.Validators[0].Address.String())
+		require.Equal(t, valB.Address, vals.Validators[1].Address.String())
+	})
+}
+
+// toBftValidator converts a proto test Validator to a bfttypes.Validator for
+// cross-checking against Gno's native constructor.
+func toBftValidator(v *Validator) *bfttypes.Validator {
+	addr, err := crypto.AddressFromString(v.Address)
+	if err != nil {
+		panic(err)
+	}
+	return &bfttypes.Validator{
+		Address:     addr,
+		PubKey:      ed25519.PubKeyEd25519(v.PubKey.GetEd25519()),
+		VotingPower: v.VotingPower,
 	}
 }
 


### PR DESCRIPTION
Fixed:
- Gno light client accepts malformed validator sets (negative voting power)
- Gno light client delay-period uint64 overflow bypasses delay gate