### PR TITLE
fix(scripts): adapt upgrade-node.sh to SDK v0.50

### DIFF
--- a/contrib/localnet/proposal_upgrade.json
+++ b/contrib/localnet/proposal_upgrade.json
@@ -4,7 +4,7 @@
       "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
       "authority": "atone10d07y265gmmuvt4z0w9aw880jnsr700j5z0zqt",
       "plan": {
-        "name": "v4",
+        "name": "v5",
         "time": "0001-01-01T00:00:00Z",
         "height": "30",
         "info": "",

--- a/contrib/scripts/upgrade-node.sh
+++ b/contrib/scripts/upgrade-node.sh
@@ -22,8 +22,8 @@ sleep 2
 echo "init with previous atomoned binary"
 rm -rf $localnet_home prev.log new.log
 $localnetd init localnet --default-denom uatone --chain-id localnet
-$localnetd config chain-id localnet
-$localnetd config keyring-backend test
+$localnetd config set client chain-id localnet
+$localnetd config set client keyring-backend test
 $localnetd keys add val
 $localnetd genesis add-genesis-account val 1000000000000uatone,1000000000uphoton
 $localnetd keys add user
@@ -35,6 +35,9 @@ $localnetd genesis add-genesis-account atone1qqqqqqqqqqqqqqqqqqqqqqqqqqqqp0dqtal
 # Add CP funds
 $localnetd genesis add-genesis-account atone1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8flcml8 5388766663072uatone
 jq '.app_state.distribution.fee_pool.community_pool = [ { "denom": "uatone", "amount": "5388766663072.000000000000000000" }]' $localnet_home/config/genesis.json > /tmp/gen
+mv /tmp/gen $localnet_home/config/genesis.json
+# Set dynamicfee fee denom to uphoton so photon fees can be resolved
+jq '.app_state.dynamicfee.params.fee_denom = "uphoton"' $localnet_home/config/genesis.json > /tmp/gen
 mv /tmp/gen $localnet_home/config/genesis.json
 # Previous add-genesis-account call added the auth module account as a BaseAccount, we need to remove it
 jq 'del(.app_state.auth.accounts[] | select(.address == "atone1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8flcml8"))' $localnet_home/config/genesis.json > /tmp/gen
@@ -105,13 +108,13 @@ if [ "$vote_code" != "0" ]; then
     exit 1
 fi
 # Query proposal to get upgrade height
-upgrade_height=$($localnetd q gov proposal 1 --output json | jq -r '.messages[0].plan.height')
+upgrade_height=$($localnetd q gov proposal 1 --output json | jq -r '.proposal.messages[0].value.plan.height')
 echo "Proposal should pass! Chain will halt at block height: $upgrade_height"
 echo "Waiting for chain to reach upgrade height..."
 
 # Poll chain height until it reaches upgrade height
 while true; do
-    current_height=$($localnetd status 2>&1 | jq -r '.SyncInfo.latest_block_height' 2>/dev/null || echo "0")
+    current_height=$($localnetd status 2>&1 | jq -r '.sync_info.latest_block_height' 2>/dev/null || echo "0")
     echo "Current height: $current_height / Upgrade height: $upgrade_height"
 
     if [ "$current_height" -ge "$upgrade_height" ]; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,13 +44,55 @@ Copy/paste the mnemonic and you're done.
 
 Chain upgrade is an important procedure that should be tested carefully. This
 section aims to provide a guide for testing chain upgrades in AtomOne using a
-localnet. 
+localnet.
+
+### Automated: `contrib/scripts/upgrade-node.sh`
+
+The script runs the whole upgrade flow unattended: it starts a localnet with
+the *previous* binary, submits and passes the upgrade proposal, waits for the
+halt height, then restarts the chain with the *new* binary.
+
+1. Update `contrib/localnet/proposal_upgrade.json` with the correct plan name,
+   which means the exact `UpgradeName` used to qualify the upgrade in the
+   next version. For instance for the v4 upgrade, the plan name is `v4` (see
+   the `app/upgrades` folder).
+2. Build the two binaries, the one to upgrade from and the one to upgrade to:
+   ```sh
+   git checkout v4.1.0 && make build && cp build/atomoned /tmp/atomoned-prev
+   git checkout main   && make build && cp build/atomoned /tmp/atomoned-new
+   ```
+3. Run the script from the repository root:
+   ```sh
+   ATOMONED_BIN=/tmp/atomoned-prev \
+   ATOMONED_NEW_BIN=/tmp/atomoned-new \
+   ./contrib/scripts/upgrade-node.sh
+   ```
+
+The script fails fast if any transaction returns a non-zero code, and prints
+the last lines of the previous binary's log (which should contain the
+`UPGRADE "<plan>" NEEDED` error) before starting the new binary. Block
+production restarting with the new binary means the upgrade handler ran
+successfully.
+
+Notes:
+
+- It must be run from the repository root, as it reads
+  `contrib/localnet/constitution-mock.md` from a relative path.
+- It deletes `~/.atomone-localnet` and kills any running `atomoned start`
+  process.
+- The voting period is lowered to 60s, so the whole run takes a couple of
+  minutes. Logs are written to `prev.log` and `new.log` in the current
+  directory.
+- The previous binary must be recent enough to support the CLI and output
+  formats the script relies on (SDK v0.50, i.e. v4 and above).
+
+### Alternative: manual localnet upgrade
 
 1. Git checkout the version of AtomOne you want to upgrade from.
-2. Update `contrib/localnet/upgrade_proposal.json` with the correct plan name,
+2. Update `contrib/localnet/proposal_upgrade.json` with the correct plan name,
    which means the exact `UpgradeName` used to qualify the upgrade in the
    next version. For instance for the v2 upgrade, the plan name is `v2` (see
-   the `app/upgrade` folder).
+   the `app/upgrades` folder).
 3. Run `make localnet-start` to start a new localnet.
 4. Run `make localnet-submit-upgrade-proposal` to submit the upgrade proposal
    and give it enough yes votes for passing the tally.


### PR DESCRIPTION
## Description

Adapts `contrib/scripts/upgrade-node.sh` to the SDK v0.50 bump (v4 upgrade):

- `config` command now requires the `set client <key> <value>` form
- `q gov proposal` output nests the proposal under `.proposal` and wraps `Any` messages in a `value` field
- `status` output keys are now snake_case (`sync_info` instead of `SyncInfo`, see cosmos/cosmos-sdk#17184)
- Set the dynamicfee fee denom to `uphoton` in genesis so photon fees can be resolved