### PR TITLE
fix: limit `authz.MsgExec` nesting depth in ante decorators and coredaos VetoProposal msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix broken testnet subcommands [#337](https://github.com/atomone-hub/atomone/pull/337)
 - Use checked addition when computing `10-gno` light client delay periods to avoid `uint64` overflow bypassing the delay gate [#341](https://github.com/atomone-hub/atomone/pull/341)
 - Validate `10-gno` validator sets during conversion (reject negative/zero voting power, duplicate addresses, and out-of-bounds totals) to prevent forged light client updates [#341](https://github.com/atomone-hub/atomone/pull/341)
+- Limit `authz.MsgExec` nesting depth for ante decorators and coredaos veto message [#344](https://github.com/atomone-hub/atomone/pull/344)
 
 ### DEPENDENCIES
 

--- a/ante/gov_ante_utils.go
+++ b/ante/gov_ante_utils.go
@@ -10,11 +10,20 @@ import (
 	atomoneerrors "github.com/atomone-hub/atomone/types/errors"
 )
 
+const maxAuthzNestingDepth = 8
+
 // iterateMsg calls fn for each message in msgs. For authz.MsgExec messages,
 // fn is called for each inner message instead of the exec message itself.
 // Nested MsgExec wrappers are expanded recursively.
 // Returns ErrUnauthorized if an inner message cannot be unpacked.
 func iterateMsg(cdc codec.BinaryCodec, msgs []sdk.Msg, fn func(sdk.Msg) error) error {
+	return iterateMsgWithDepth(cdc, msgs, 0, fn)
+}
+
+func iterateMsgWithDepth(cdc codec.BinaryCodec, msgs []sdk.Msg, depth int, fn func(sdk.Msg) error) error {
+	if depth > maxAuthzNestingDepth {
+		return errorsmod.Wrap(atomoneerrors.ErrUnauthorized, "authz nesting depth exceeded")
+	}
 	for _, m := range msgs {
 		if execMsg, ok := m.(*authz.MsgExec); ok {
 			for _, anyInner := range execMsg.Msgs {
@@ -23,7 +32,7 @@ func iterateMsg(cdc codec.BinaryCodec, msgs []sdk.Msg, fn func(sdk.Msg) error) e
 					return errorsmod.Wrap(atomoneerrors.ErrUnauthorized, "cannot unmarshal authz exec msgs")
 				}
 				// Recurse to handle nested MsgExec wrappers.
-				if err := iterateMsg(cdc, []sdk.Msg{inner}, fn); err != nil {
+				if err := iterateMsgWithDepth(cdc, []sdk.Msg{inner}, depth+1, fn); err != nil {
 					return err
 				}
 			}

--- a/ante/gov_submit_proposal_ante.go
+++ b/ante/gov_submit_proposal_ante.go
@@ -93,7 +93,10 @@ func addressChanged(newAddr, currentAddr string) (bool, error) {
 // bundled with other messages. authz.MsgExec wrappers are expanded recursively
 // so that nested oversight-DAO changes are also detected.
 func (g GovSubmitProposalDecorator) validateProposalMessages(ctx sdk.Context, anyMsgs []*codectypes.Any) error {
-	effectiveMsgs := coredaostypes.FlattenAnyMsgs(g.cdc, anyMsgs)
+	effectiveMsgs, err := coredaostypes.FlattenAnyMsgs(g.cdc, anyMsgs)
+	if err != nil {
+		return err
+	}
 
 	// Bundling is only possible when there is more than one effective message.
 	if len(effectiveMsgs) <= 1 {

--- a/ante/gov_vote_ante_authz_test.go
+++ b/ante/gov_vote_ante_authz_test.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/math"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
@@ -70,4 +71,73 @@ func TestVoteSpamDecoratorAuthz(t *testing.T) {
 	nestedExecMsg = authz.NewMsgExec(granteeAddr, []sdk.Msg{&execGoodMsg, &execMsg})
 	err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{&nestedExecMsg})
 	require.Error(t, err)
+}
+
+// maxAuthzNestingDepth mirrors the unexported constant in gov_ante_utils.go:
+// iterateMsg rejects authz.MsgExec nestings strictly deeper than this value.
+const maxAuthzNestingDepth = 8
+
+// nestInMsgExec wraps leaf in `depth` nested authz.MsgExec layers and returns the
+// outermost wrapper as an sdk.Msg.
+func nestInMsgExec(t *testing.T, grantee sdk.AccAddress, leaf sdk.Msg, depth int) sdk.Msg {
+	t.Helper()
+	require.GreaterOrEqual(t, depth, 1)
+	cur, err := codectypes.NewAnyWithValue(leaf)
+	require.NoError(t, err)
+	var exec *authz.MsgExec
+	for i := 0; i < depth; i++ {
+		exec = &authz.MsgExec{Grantee: grantee.String(), Msgs: []*codectypes.Any{cur}}
+		cur, err = codectypes.NewAnyWithValue(exec)
+		require.NoError(t, err)
+	}
+	return exec
+}
+
+// TestVoteSpamDecoratorAuthzNestingDepth checks that authz.MsgExec wrappers are
+// only expanded up to maxAuthzNestingDepth levels, so a deeply-nested wrapper
+// cannot be used to exhaust resources or bypass the vote check.
+func TestVoteSpamDecoratorAuthzNestingDepth(t *testing.T) {
+	atomoneApp := helpers.Setup(t)
+	ctx := atomoneApp.NewUncachedContext(true, tmproto.Header{})
+	decorator := ante.NewGovVoteDecorator(atomoneApp.AppCodec(), atomoneApp.StakingKeeper)
+	stakingKeeper := atomoneApp.StakingKeeper
+
+	valAddrs, err := stakingKeeper.GetAllValidators(ctx)
+	require.NoError(t, err)
+	valAddr1, err := stakingKeeper.ValidatorAddressCodec().StringToBytes(valAddrs[0].OperatorAddress)
+	require.NoError(t, err)
+
+	// This account was created during setup.
+	delegator, err := atomoneApp.AccountKeeper.Accounts.Indexes.Number.MatchExact(ctx, 0)
+	require.NoError(t, err)
+
+	granteeAddr := sdk.AccAddress(ed25519.GenPrivKeyFromSecret([]byte{uint8(14)}).PubKey().Address())
+
+	// Delegate enough stake so the inner vote passes the stake check: the only
+	// reason a deeply-nested wrapper gets rejected is the nesting-depth limit.
+	val, err := stakingKeeper.GetValidator(ctx, valAddr1)
+	require.NoError(t, err)
+	_, err = stakingKeeper.Delegate(ctx, delegator, math.NewInt(1000000), stakingtypes.Unbonded, val, true)
+	require.NoError(t, err)
+
+	validVote := govv1beta1.NewMsgVote(delegator, 0, govv1beta1.OptionYes)
+
+	// At the limit: the inner vote is reached and validates successfully.
+	atLimit := nestInMsgExec(t, granteeAddr, validVote, maxAuthzNestingDepth)
+	require.NoError(t, decorator.ValidateVoteMsgs(ctx, []sdk.Msg{atLimit}))
+
+	// At the limit with an invalid inner vote: rejected, but for the inner vote's
+	// own reason (empty voter) rather than the depth limit. This proves the inner
+	// message is actually reached and checked at the limit.
+	invalidVote := govv1beta1.NewMsgVote(nil, 0, govv1beta1.OptionYes)
+	atLimitInvalid := nestInMsgExec(t, granteeAddr, invalidVote, maxAuthzNestingDepth)
+	err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{atLimitInvalid})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "authz nesting depth exceeded")
+
+	// One layer beyond the limit: rejected before reaching the inner vote.
+	beyondLimit := nestInMsgExec(t, granteeAddr, validVote, maxAuthzNestingDepth+1)
+	err = decorator.ValidateVoteMsgs(ctx, []sdk.Msg{beyondLimit})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "authz nesting depth exceeded")
 }

--- a/x/coredaos/keeper/msg_server.go
+++ b/x/coredaos/keeper/msg_server.go
@@ -386,7 +386,11 @@ func (ms MsgServer) VetoProposal(goCtx context.Context, msg *types.MsgVetoPropos
 	// Check if the proposal contains a change of the oversight DAO address.
 	// If so, vetoing the proposal would create a scenario where the current oversight DAO can prevent its own replacement.
 	// authz.MsgExec wrappers are expanded recursively so the check cannot be bypassed by wrapping MsgUpdateParams.
-	for _, flatMsg := range types.FlattenAnyMsgs(ms.k.cdc, proposal.Messages) {
+	effectiveMsgs, err := types.FlattenAnyMsgs(ms.k.cdc, proposal.Messages)
+	if err != nil {
+		return nil, err
+	}
+	for _, flatMsg := range effectiveMsgs {
 		updateParamsMsg, ok := flatMsg.(*types.MsgUpdateParams)
 		if !ok {
 			continue

--- a/x/coredaos/types/utils.go
+++ b/x/coredaos/types/utils.go
@@ -1,16 +1,29 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	atomoneerrors "github.com/atomone-hub/atomone/types/errors"
 )
+
+const maxAuthzNestingDepth = 8
 
 // FlattenAnyMsgs recursively unpacks Any-encoded messages, expanding
 // authz.MsgExec wrappers so that all leaf messages are returned in a flat
 // slice. Entries that cannot be unpacked are represented as nil.
-func FlattenAnyMsgs(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any) []sdk.Msg {
+func FlattenAnyMsgs(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any) ([]sdk.Msg, error) {
+	return flattenAnyMsgsWithDepth(cdc, anyMsgs, 0)
+}
+
+func flattenAnyMsgsWithDepth(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any, depth int) ([]sdk.Msg, error) {
+	if depth > maxAuthzNestingDepth {
+		return nil, errorsmod.Wrap(atomoneerrors.ErrUnauthorized, "authz nesting depth exceeded")
+	}
 	var result []sdk.Msg
 	for _, anyMsg := range anyMsgs {
 		var msg sdk.Msg
@@ -19,10 +32,14 @@ func FlattenAnyMsgs(cdc codec.BinaryCodec, anyMsgs []*codectypes.Any) []sdk.Msg 
 			continue
 		}
 		if execMsg, ok := msg.(*authz.MsgExec); ok {
-			result = append(result, FlattenAnyMsgs(cdc, execMsg.Msgs)...)
+			subMsgs, err := flattenAnyMsgsWithDepth(cdc, execMsg.Msgs, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, subMsgs...)
 		} else {
 			result = append(result, msg)
 		}
 	}
-	return result
+	return result, nil
 }

--- a/x/coredaos/types/utils_test.go
+++ b/x/coredaos/types/utils_test.go
@@ -1,0 +1,99 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	"github.com/atomone-hub/atomone/x/coredaos/types"
+)
+
+// maxAuthzNestingDepth mirrors the unexported constant in utils.go. FlattenAnyMsgs
+// rejects nestings strictly deeper than this value.
+const maxAuthzNestingDepth = 8
+
+func flattenTestCodec() codec.BinaryCodec {
+	registry := codectypes.NewInterfaceRegistry()
+	authz.RegisterInterfaces(registry)
+	types.RegisterInterfaces(registry)
+	return codec.NewProtoCodec(registry)
+}
+
+// wrapMsgExec wraps inner in `depth` nested authz.MsgExec layers and returns the
+// outermost message as an Any. depth == 0 returns inner unchanged.
+func wrapMsgExec(t *testing.T, inner *codectypes.Any, depth int) *codectypes.Any {
+	t.Helper()
+	cur := inner
+	for i := 0; i < depth; i++ {
+		any, err := codectypes.NewAnyWithValue(&authz.MsgExec{
+			Grantee: sdk.AccAddress("grantee").String(),
+			Msgs:    []*codectypes.Any{cur},
+		})
+		require.NoError(t, err)
+		cur = any
+	}
+	return cur
+}
+
+func mustPackMsg(t *testing.T, msg sdk.Msg) *codectypes.Any {
+	t.Helper()
+	any, err := codectypes.NewAnyWithValue(msg)
+	require.NoError(t, err)
+	return any
+}
+
+func TestFlattenAnyMsgs(t *testing.T) {
+	cdc := flattenTestCodec()
+
+	leaf := &types.MsgUpdateParams{
+		Params: types.Params{OversightDaoAddress: "the-leaf-address"},
+	}
+
+	t.Run("bare message is returned as-is", func(t *testing.T) {
+		out, err := types.FlattenAnyMsgs(cdc, []*codectypes.Any{mustPackMsg(t, leaf)})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		updateParams, ok := out[0].(*types.MsgUpdateParams)
+		require.True(t, ok)
+		require.Equal(t, "the-leaf-address", updateParams.Params.OversightDaoAddress)
+	})
+
+	t.Run("multiple wrappers and bare messages are all flattened", func(t *testing.T) {
+		out, err := types.FlattenAnyMsgs(cdc, []*codectypes.Any{
+			wrapMsgExec(t, mustPackMsg(t, leaf), 1),
+			wrapMsgExec(t, mustPackMsg(t, leaf), 2),
+			mustPackMsg(t, leaf),
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 3)
+		for _, m := range out {
+			updateParams, ok := m.(*types.MsgUpdateParams)
+			require.True(t, ok)
+			require.Equal(t, "the-leaf-address", updateParams.Params.OversightDaoAddress)
+		}
+	})
+
+	t.Run("nesting at the limit is accepted", func(t *testing.T) {
+		out, err := types.FlattenAnyMsgs(cdc, []*codectypes.Any{
+			wrapMsgExec(t, mustPackMsg(t, leaf), maxAuthzNestingDepth),
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		_, ok := out[0].(*types.MsgUpdateParams)
+		require.True(t, ok)
+	})
+
+	t.Run("nesting beyond the limit is rejected", func(t *testing.T) {
+		out, err := types.FlattenAnyMsgs(cdc, []*codectypes.Any{
+			wrapMsgExec(t, mustPackMsg(t, leaf), maxAuthzNestingDepth+1),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "authz nesting depth exceeded")
+		require.Nil(t, out)
+	})
+}


### PR DESCRIPTION
Unbounded nesting could be potentially abused to cause slowdowns. This PR limits nesting to a depth of 8 (arbitrary constants) in 2 places (constants kept separate for cleanliness) affecting the `GovSubmitProposalDecorator` and `GovVoteDecorator` ante decorators as well as the `x/coredaos` `VetoProposal` message.