### PR TITLE
chore: bump cosmos-sdk to v0.500.0 final

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 replace (
 	cosmossdk.io/x/feegrant => cosmossdk.io/x/feegrant v0.1.1
 	cosmossdk.io/x/upgrade => github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2
-	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.0-rc3
+	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.0
 	github.com/cosmos/ibc-go/v10 => github.com/cosmos/ibc-go/v10 v10.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/atomone-hub/cosmos-sdk v0.500.0-rc3 h1:9mK2wYKxGg0+j14T63mLmWZ/iRiaGLiip+nG3cijh0E=
-github.com/atomone-hub/cosmos-sdk v0.500.0-rc3/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
+github.com/atomone-hub/cosmos-sdk v0.500.0 h1:eR+bzYe6LCMxBvQcU0fAQa6DiswdxhxAHYPIYyACLA4=
+github.com/atomone-hub/cosmos-sdk v0.500.0/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2 h1:SVPsm3c8pymdbwNjKHF5vwM0B6x4dgkVTbhbYctwBoE=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2/go.mod h1:78DcDK3kSaNN7dObcV1FIypDDIfl5W5X1uDyrUyZmWY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=

--- a/x/coredaos/keeper/hooks.go
+++ b/x/coredaos/keeper/hooks.go
@@ -6,6 +6,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
@@ -69,6 +70,10 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, consAddr sdk.Co
 }
 
 func (h Hooks) AfterUnbondingInitiated(ctx context.Context, unbondingID uint64) error {
+	return nil
+}
+
+func (h Hooks) AfterConsensusPubKeyUpdate(ctx context.Context, oldPk, newPk cryptotypes.PubKey, fee sdk.Coin) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Bumps the cosmos-sdk fork from the release candidate to the **final `v0.500.0`** tag, the last dependency blocking the v4.0.0 release.

> **Note:** The SDK final bump was part of #343 originally, but only that PR's first commit (ibc-go v10.7.0 / Go 1.26.4 / module security bumps) landed on `main` — the SDK commit did not. This PR re-applies it on top of current `main`.

## Changes

- **`go.mod`**: `cosmos-sdk => atomone-hub/cosmos-sdk v0.500.0-rc3` → `v0.500.0`.
- **`x/coredaos/keeper/hooks.go`**: the final SDK added `AfterConsensusPubKeyUpdate(ctx, oldPk, newPk, fee)` to the `StakingHooks` interface (validator consensus pubkey rotation). `x/coredaos` is the only `StakingHooks` implementer in the repo; implemented as a no-op, consistent with the module's other non-delegation hooks.

⚠️ **Reviewer note:** the final SDK enabling consensus pubkey rotation likely introduces new staking params (rotation fee, max rotations). Confirm whether the **v4 upgrade handler** needs to initialize them — `RunMigrations` runs the staking migration, but any chain-specific non-default values must be set explicitly in the handler.

## Verification

- `go build ./...` ✅
- `go test ./x/... ./ante/... ./post/... ./app/...` ✅
- `govulncheck ./...` → **No vulnerabilities found** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)