### PR TITLE
chore: prepare CHANGELOG for v4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## v4.0.0
 
-*Release date*
+*Jun 22nd, 2026*
 
 ### API BREAKING
 
@@ -21,6 +21,7 @@
 
 ### DEPENDENCIES
 
+- Upgrade Cosmos SDK to the Atom One `v0.50` fork (`v0.500.0`) [#340](https://github.com/atomone-hub/atomone/pull/340) [#346](https://github.com/atomone-hub/atomone/pull/346)
 - Upgrade CometBFT to v0.38.19 to fix security issue (ASA-2025-003) [#234](https://github.com/atomone-hub/atomone/pull/234)
 - Upgrade CometBFT to v0.38.21 to fix security issue (CSA-2026-001) [#270](https://github.com/atomone-hub/atomone/pull/270)
 - Upgrade CometBFT to v0.38.23 to fix security issue [#332](https://github.com/atomone-hub/atomone/pull/332)


### PR DESCRIPTION
## Summary

Finalizes the CHANGELOG for the **v4.0.0** release.

## Changes

- `## Unreleased` → `## v4.0.0`.
- ⚠️ Stamped the release date as **Jun 22nd, 2026** (today). **Adjust this to the actual tag date** if v4.0.0 is tagged on a different day.
- Added the headline **Cosmos SDK v0.50** upgrade to the DEPENDENCIES section — the defining dependency change of v4, which was previously unrecorded there (only the rc bump #340 and the final bump #346 reference it).

## Notes

- Depends on **#346** (cosmos-sdk v0.500.0 final) — that PR is referenced in the new SDK DEPENDENCIES entry and should merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)