### PR TITLE
chore: bump cosmos-sdk to v0.500.1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## v4.0.0
 
-*Release date*
+*Jun 23nd, 2026*
 
 ### API BREAKING
 
@@ -21,6 +21,7 @@
 
 ### DEPENDENCIES
 
+- Upgrade Cosmos SDK to the Atom One `v0.50` fork (`v0.500.1`) [#348](https://github.com/atomone-hub/atomone/pull/348)
 - Upgrade CometBFT to v0.38.19 to fix security issue (ASA-2025-003) [#234](https://github.com/atomone-hub/atomone/pull/234)
 - Upgrade CometBFT to v0.38.21 to fix security issue (CSA-2026-001) [#270](https://github.com/atomone-hub/atomone/pull/270)
 - Upgrade CometBFT to v0.38.23 to fix security issue [#332](https://github.com/atomone-hub/atomone/pull/332)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
 TEST_DOCKER_REPO=cosmos/contrib-atomonetest
 
-GO_SYSTEM_VERSION = $(shell go env GOVERSION | cut -c 3-)
+GO_SYSTEM_VERSION = $(shell go env GOVERSION | sed 's/^go//;s/-.*//')
 GO_REQUIRED_VERSION = $(shell go list -f {{.GoVersion}} -m)
 
 # command to run dependency utilities

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -219,6 +219,8 @@ func NewAppKeeper(
 		authorityStr,
 	)
 
+	appKeepers.StakingKeeper.SetDistributionKeeper(appKeepers.DistrKeeper)
+
 	appKeepers.EpochsKeeper = epochskeeper.NewKeeper(
 		runtime.NewKVStoreService(appKeepers.keys[epochstypes.StoreKey]),
 		appCodec,

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -625,8 +625,8 @@ func MigrateStakingParams(ctx context.Context, stakingKeeper *stakingkeeper.Keep
 	params.MaxCommissionRate = fivePercent
 	params.MinCommissionRate = fivePercent
 
-	// Initialize the consensus pubkey rotation fee to 1 ATONE, denominated in the chain bond denom.
-	params.KeyRotationFee = sdk.NewCoin(params.BondDenom, math.NewInt(1_000_000))
+	// Initialize the consensus pubkey rotation fee to 100 ATONEs
+	params.KeyRotationFee = sdk.NewCoin(params.BondDenom, math.NewInt(100_000000))
 
 	if err := stakingKeeper.SetParams(ctx, params); err != nil {
 		return err

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -48,7 +48,7 @@ func CreateUpgradeHandler(
 			return vm, err
 		}
 
-		if err := migrateValidatorsCommission(ctx, keepers.StakingKeeper); err != nil {
+		if err := migrateStakingParams(ctx, keepers.StakingKeeper); err != nil {
 			return vm, err
 		}
 
@@ -609,8 +609,11 @@ func governorValSharesValueCodec(cdc codec.Codec) collcodec.ValueCodec[sdkgovv1.
 	})
 }
 
-// migrateValidatorsCommission sets the chain-wide commission to the constitutionally-mandated 5% and updates all existing validator's commission accordingly.
-func migrateValidatorsCommission(ctx context.Context, stakingKeeper *stakingkeeper.Keeper) error {
+// migrateStakingParams sets the chain-wide commission to the
+// constitutionally-mandated 5% and updates all existing validator's commission
+// accordingly. It also initializes the KeyRotationFee param introduced by the
+// consensus pubkey rotation feature.
+func migrateStakingParams(ctx context.Context, stakingKeeper *stakingkeeper.Keeper) error {
 	// Set chain-wide commission to 5%
 	params, err := stakingKeeper.GetParams(ctx)
 	if err != nil {
@@ -621,6 +624,10 @@ func migrateValidatorsCommission(ctx context.Context, stakingKeeper *stakingkeep
 
 	params.MaxCommissionRate = fivePercent
 	params.MinCommissionRate = fivePercent
+
+	// Initialize the consensus pubkey rotation fee to 1 ATONE, denominated in the chain bond denom.
+	params.KeyRotationFee = sdk.NewCoin(params.BondDenom, math.NewInt(1_000_000))
+
 	if err := stakingKeeper.SetParams(ctx, params); err != nil {
 		return err
 	}

--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -48,7 +48,7 @@ func CreateUpgradeHandler(
 			return vm, err
 		}
 
-		if err := migrateStakingParams(ctx, keepers.StakingKeeper); err != nil {
+		if err := MigrateStakingParams(ctx, keepers.StakingKeeper); err != nil {
 			return vm, err
 		}
 
@@ -609,11 +609,11 @@ func governorValSharesValueCodec(cdc codec.Codec) collcodec.ValueCodec[sdkgovv1.
 	})
 }
 
-// migrateStakingParams sets the chain-wide commission to the
+// MigrateStakingParams sets the chain-wide commission to the
 // constitutionally-mandated 5% and updates all existing validator's commission
 // accordingly. It also initializes the KeyRotationFee param introduced by the
 // consensus pubkey rotation feature.
-func migrateStakingParams(ctx context.Context, stakingKeeper *stakingkeeper.Keeper) error {
+func MigrateStakingParams(ctx context.Context, stakingKeeper *stakingkeeper.Keeper) error {
 	// Set chain-wide commission to 5%
 	params, err := stakingKeeper.GetParams(ctx)
 	if err != nil {

--- a/app/upgrades/v4/upgrades_test.go
+++ b/app/upgrades/v4/upgrades_test.go
@@ -1,0 +1,32 @@
+package v4_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/atomone-hub/atomone/app/helpers"
+	v4 "github.com/atomone-hub/atomone/app/upgrades/v4"
+)
+
+func TestMigrateStakingParams(t *testing.T) {
+	app := helpers.Setup(t)
+	ctx := app.NewUncachedContext(false, cmtproto.Header{})
+	sk := app.StakingKeeper
+
+	require.NoError(t, v4.MigrateStakingParams(ctx, sk))
+
+	got, err := sk.GetParams(ctx)
+	require.NoError(t, err)
+	require.NoError(t, got.Validate())
+	require.Equal(t, sdk.NewCoin(got.BondDenom, math.NewInt(1_000_000)), got.KeyRotationFee)
+	fivePercent := math.LegacyMustNewDecFromStr("0.05")
+	require.Equal(t, fivePercent, got.MinCommissionRate)
+	require.Equal(t, fivePercent, got.MaxCommissionRate)
+}

--- a/app/upgrades/v4/upgrades_test.go
+++ b/app/upgrades/v4/upgrades_test.go
@@ -25,7 +25,7 @@ func TestMigrateStakingParams(t *testing.T) {
 	got, err := sk.GetParams(ctx)
 	require.NoError(t, err)
 	require.NoError(t, got.Validate())
-	require.Equal(t, sdk.NewCoin(got.BondDenom, math.NewInt(1_000_000)), got.KeyRotationFee)
+	require.Equal(t, sdk.NewCoin(got.BondDenom, math.NewInt(100_000000)), got.KeyRotationFee)
 	fivePercent := math.LegacyMustNewDecFromStr("0.05")
 	require.Equal(t, fivePercent, got.MinCommissionRate)
 	require.Equal(t, fivePercent, got.MaxCommissionRate)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 replace (
 	cosmossdk.io/x/feegrant => cosmossdk.io/x/feegrant v0.1.1
 	cosmossdk.io/x/upgrade => github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2
-	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.0
+	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.1
 	github.com/cosmos/ibc-go/v10 => github.com/cosmos/ibc-go/v10 v10.7.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 replace (
 	cosmossdk.io/x/feegrant => cosmossdk.io/x/feegrant v0.1.1
 	cosmossdk.io/x/upgrade => github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2
-	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.0-rc3
+	github.com/cosmos/cosmos-sdk => github.com/atomone-hub/cosmos-sdk v0.500.0
 	github.com/cosmos/ibc-go/v10 => github.com/cosmos/ibc-go/v10 v10.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/atomone-hub/cosmos-sdk v0.500.0-rc3 h1:9mK2wYKxGg0+j14T63mLmWZ/iRiaGLiip+nG3cijh0E=
-github.com/atomone-hub/cosmos-sdk v0.500.0-rc3/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
+github.com/atomone-hub/cosmos-sdk v0.500.0 h1:eR+bzYe6LCMxBvQcU0fAQa6DiswdxhxAHYPIYyACLA4=
+github.com/atomone-hub/cosmos-sdk v0.500.0/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2 h1:SVPsm3c8pymdbwNjKHF5vwM0B6x4dgkVTbhbYctwBoE=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2/go.mod h1:78DcDK3kSaNN7dObcV1FIypDDIfl5W5X1uDyrUyZmWY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
-github.com/atomone-hub/cosmos-sdk v0.500.0 h1:eR+bzYe6LCMxBvQcU0fAQa6DiswdxhxAHYPIYyACLA4=
-github.com/atomone-hub/cosmos-sdk v0.500.0/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
+github.com/atomone-hub/cosmos-sdk v0.500.1 h1:1/sNalNS6blWUm7iLXzC+RnGFsxMLdXKs33rNjNk8DI=
+github.com/atomone-hub/cosmos-sdk v0.500.1/go.mod h1:bV+SvzTTjmJ10xv0SaROxOZxp96Q4bmi8nnT2CpxkWc=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2 h1:SVPsm3c8pymdbwNjKHF5vwM0B6x4dgkVTbhbYctwBoE=
 github.com/atomone-hub/cosmos-sdk/x/upgrade v0.1.5-atomone.2/go.mod h1:78DcDK3kSaNN7dObcV1FIypDDIfl5W5X1uDyrUyZmWY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=

--- a/x/coredaos/keeper/hooks.go
+++ b/x/coredaos/keeper/hooks.go
@@ -6,6 +6,7 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
@@ -69,6 +70,10 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx context.Context, consAddr sdk.Co
 }
 
 func (h Hooks) AfterUnbondingInitiated(ctx context.Context, unbondingID uint64) error {
+	return nil
+}
+
+func (h Hooks) AfterConsensusPubKeyUpdate(ctx context.Context, oldPk, newPk cryptotypes.PubKey, fee sdk.Coin) error {
 	return nil
 }
 


### PR DESCRIPTION
Compat with consensus key rotation:
- Satisfy StakingHook interface as a no-op in x/coredaos
- Add migration for the new staking params rotationFee.
- Add distribution keeper to staking keeper