### PR TITLE
fix(photon): prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## Unreleased
+
+### API BREAKING
+
+### BUG FIXES
+
+- Prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions in `x/photon` [#352](https://github.com/atomone-hub/atomone/pull/352)
+
+### DEPENDENCIES
+
+### FEATURES
+
+### STATE BREAKING
+
+### IMPROVEMENTS
+
 ## v4.0.0
 
 *Jun 23nd, 2026*

--- a/proto/atomone/photon/v1/photon.proto
+++ b/proto/atomone/photon/v1/photon.proto
@@ -10,5 +10,7 @@ message Params {
   // tx_fee_exceptions holds the msg type urls that are allowed to use some
   // different tx fee coins than photon.
   // A wildcard "*" can be used to allow all transactions to use any fee denom.
+  // When used, "*" must be the sole entry; combining it with specific message
+  // type URLs is contradictory and rejected during parameter validation.
   repeated string tx_fee_exceptions = 2;
 }

--- a/x/photon/types/params.go
+++ b/x/photon/types/params.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"slices"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
 // NewParams creates a new Params instance
 func NewParams(mintDisabled bool, txFeeExceptions []string) Params {
 	return Params{
@@ -21,7 +27,15 @@ func DefaultParams() Params {
 	return NewParams(defaultMintDisabled, defaultTxFeeExceptions)
 }
 
-// Validate validates the set of params
+// ValidateBasic validates the set of params
 func (p Params) ValidateBasic() error {
+	// If used, the wildcard "*" in TxFeeExceptions must be the sole entry.
+	// Mixing it with specific message type URLs is contradictory and rejected here.
+	if slices.Contains(p.TxFeeExceptions, "*") && len(p.TxFeeExceptions) != 1 {
+		return sdkerrors.ErrInvalidRequest.Wrapf(
+			"tx_fee_exceptions: wildcard \"*\" must be the sole entry when used (got %d entries)",
+			len(p.TxFeeExceptions),
+		)
+	}
 	return nil
 }

--- a/x/photon/types/params_test.go
+++ b/x/photon/types/params_test.go
@@ -1,0 +1,70 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/atomone-hub/atomone/x/photon/types"
+)
+
+func TestParams_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  types.Params
+		wantErr bool
+	}{
+		{
+			name:   "default params",
+			params: types.DefaultParams(),
+		},
+		{
+			name:   "empty exceptions",
+			params: types.NewParams(false, nil),
+		},
+		{
+			name:   "single specific exception",
+			params: types.NewParams(false, []string{"/atomone.photon.v1.MsgMintPhoton"}),
+		},
+		{
+			name: "multiple specific exceptions",
+			params: types.NewParams(false, []string{
+				"/atomone.photon.v1.MsgMintPhoton",
+				"/cosmos.bank.v1beta1.MsgSend",
+			}),
+		},
+		{
+			name:   "wildcard alone",
+			params: types.NewParams(false, []string{"*"}),
+		},
+		{
+			name:    "wildcard at index 0 mixed with specific",
+			params:  types.NewParams(false, []string{"*", "/atomone.photon.v1.MsgMintPhoton"}),
+			wantErr: true,
+		},
+		{
+			name:    "wildcard at index 1 mixed with specific",
+			params:  types.NewParams(false, []string{"/atomone.photon.v1.MsgMintPhoton", "*"}),
+			wantErr: true,
+		},
+		{
+			name: "wildcard at index 2 mixed with specific",
+			params: types.NewParams(false, []string{
+				"/atomone.photon.v1.MsgMintPhoton",
+				"/cosmos.gov.v1.MsgVote",
+				"*",
+			}),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/x/photon/types/photon.pb.go
+++ b/x/photon/types/photon.pb.go
@@ -29,6 +29,8 @@ type Params struct {
 	// tx_fee_exceptions holds the msg type urls that are allowed to use some
 	// different tx fee coins than photon.
 	// A wildcard "*" can be used to allow all transactions to use any fee denom.
+	// When used, "*" must be the sole entry; combining it with specific message
+	// type URLs is contradictory and rejected during parameter validation.
 	TxFeeExceptions []string `protobuf:"bytes,2,rep,name=tx_fee_exceptions,json=txFeeExceptions,proto3" json:"tx_fee_exceptions,omitempty"`
 }
 


### PR DESCRIPTION
Having the wildcard symbol `*` bundled with other messages is semantically wrong and should be prevented. The wildcard should exist by itself, and up until this PR an ill-formatted assignment for `TxFeeExceptions` of the kind `[MsgFoo, *]` would silently be accepted and result in the wildcard being ignored, since the code expects it to be the first (and essentially only) entry in the list.

Note: this is a nitpick fix, **it is not required for v4** and can be treated independently and scheduled to be deployed in a future update. There's no urgency nor any cause of concern. This PR is just for code correctness, and impact is marginal at best (also because we don't expect the `TxFeeExceptions` param to be updated any time soon)