### PR TITLE
fix(x/gov): decode pre-v4 gov params in historical queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### BUG FIXES
 
 - Prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions in `x/photon` [#352](https://github.com/atomone-hub/atomone/pull/352)
+- Decode gov params written before the v4 upgrade correctly in historical queries. Pre-v4 state uses the `atomone.gov.v1` field numbering, which the current type read one field off (v1 and v2 state) or rejected (v3 state); `TallyResult` and `Params` queries at those heights panicked or failed. The gov keeper now uses a layout-aware params codec that converts legacy bytes and pins the static quorum as the quorum range for state that predates the dynamic quorum [#366](https://github.com/atomone-hub/atomone/pull/366)
 
 ### DEPENDENCIES
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -257,9 +257,10 @@ func NewAppKeeper(
 	govConfig := govtypes.DefaultConfig()
 	// set the MaxMetadataLen for proposals to the same value as it was pre-sdk v0.47.x
 	govConfig.MaxMetadataLen = 10200
+	govStoreService := runtime.NewKVStoreService(appKeepers.keys[govtypes.StoreKey])
 	appKeepers.GovKeeper = govkeeper.NewKeeper(
 		appCodec,
-		runtime.NewKVStoreService(appKeepers.keys[govtypes.StoreKey]),
+		govStoreService,
 		appKeepers.AccountKeeper,
 		appKeepers.BankKeeper,
 		appKeepers.StakingKeeper,
@@ -268,6 +269,10 @@ func NewAppKeeper(
 		govConfig,
 		authorityStr,
 	)
+
+	// Historical queries read gov params written before the v4 migration; this codec
+	// decodes both layouts so those queries do not misread or panic on old state.
+	appKeepers.GovKeeper.Params = atomonegovkeeper.NewParamsItem(appCodec, govStoreService)
 
 	// Set legacy router for backwards compatibility with gov v1beta1
 	govRouter := govv1beta1.NewRouter()

--- a/x/gov/keeper/params_codec.go
+++ b/x/gov/keeper/params_codec.go
@@ -1,0 +1,105 @@
+package keeper
+
+import (
+	"google.golang.org/protobuf/encoding/protowire"
+
+	"cosmossdk.io/collections"
+	collcodec "cosmossdk.io/collections/codec"
+	corestoretypes "cosmossdk.io/core/store"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdkgov "github.com/cosmos/cosmos-sdk/x/gov/types"
+	sdkv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+)
+
+// legacyParamsMarkerField is a field number that only the pre-v4 atomone.gov.v1
+// Params layout defines (min_deposit_ratio). The cosmos.gov.v1 layout used since
+// the v4 upgrade renumbered every field from 15 upwards by one and has no field 15,
+// so its presence identifies bytes written before the migration.
+const legacyParamsMarkerField = 15
+
+// NewParamsItem returns a Params collection for the gov store that decodes both the
+// current cosmos.gov.v1 layout and the atomone.gov.v1 layout written before the v4
+// upgrade. The v4 upgrade migrated the stored params, but a historical query runs the
+// current binary against pre-migration state; decoding those bytes with the current
+// type silently shifts every field from 15 upwards (v1 and v2 state) or fails on the
+// wire type of field 23 (v3 state), and the missing quorum ranges then panic in
+// GetQuorum. Install it on the keeper after construction:
+//
+//	govKeeper.Params = keeper.NewParamsItem(cdc, govStoreService)
+func NewParamsItem(cdc codec.Codec, storeService corestoretypes.KVStoreService) collections.Item[sdkv1.Params] {
+	sb := collections.NewSchemaBuilder(storeService)
+	item := collections.NewItem(sb, sdkgov.ParamsKey, "params", ParamsValueCodec(cdc))
+	if _, err := sb.Build(); err != nil {
+		panic(err)
+	}
+	return item
+}
+
+// ParamsValueCodec is the value codec behind NewParamsItem. Encoding always uses the
+// current layout; decoding picks the layout from the bytes themselves.
+func ParamsValueCodec(cdc codec.Codec) collcodec.ValueCodec[sdkv1.Params] {
+	return legacyAwareParamsCodec{
+		ValueCodec: codec.CollValue[sdkv1.Params](cdc),
+		cdc:        cdc,
+	}
+}
+
+type legacyAwareParamsCodec struct {
+	collcodec.ValueCodec[sdkv1.Params]
+	cdc codec.Codec
+}
+
+// Decode implements collcodec.ValueCodec.
+func (c legacyAwareParamsCodec) Decode(b []byte) (sdkv1.Params, error) {
+	if !IsLegacyParamsLayout(b) {
+		return c.ValueCodec.Decode(b)
+	}
+	legacy := new(v1.Params)
+	if err := c.cdc.Unmarshal(b, legacy); err != nil {
+		return sdkv1.Params{}, err
+	}
+	params := v1.ConvertAtomOneParamsToSDK(legacy)
+	fillStaticQuorumRanges(params)
+	return *params, nil
+}
+
+// IsLegacyParamsLayout reports whether b is a gov Params value in the pre-v4
+// atomone.gov.v1 layout. Malformed input is treated as the current layout so the
+// regular codec reports the error.
+func IsLegacyParamsLayout(b []byte) bool {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return false
+		}
+		if num == legacyParamsMarkerField {
+			return true
+		}
+		b = b[n:]
+		n = protowire.ConsumeFieldValue(num, typ, b)
+		if n < 0 {
+			return false
+		}
+		b = b[n:]
+	}
+	return false
+}
+
+// fillStaticQuorumRanges gives params written before the dynamic quorum existed
+// (v1 and v2 state) the quorum ranges the current code expects. A range whose
+// bounds both equal the static quorum makes GetQuorum return exactly the quorum
+// the chain applied at that height, whatever the participation EMA.
+func fillStaticQuorumRanges(params *sdkv1.Params) {
+	if params.QuorumRange == nil {
+		params.QuorumRange = &sdkv1.QuorumRange{Min: params.Quorum, Max: params.Quorum}
+	}
+	if params.ConstitutionAmendmentQuorumRange == nil {
+		params.ConstitutionAmendmentQuorumRange = &sdkv1.QuorumRange{Min: params.ConstitutionAmendmentQuorum, Max: params.ConstitutionAmendmentQuorum}
+	}
+	if params.LawQuorumRange == nil {
+		params.LawQuorumRange = &sdkv1.QuorumRange{Min: params.LawQuorum, Max: params.LawQuorum}
+	}
+}

--- a/x/gov/keeper/params_codec_test.go
+++ b/x/gov/keeper/params_codec_test.go
@@ -1,0 +1,110 @@
+package keeper_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdkv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	"github.com/atomone-hub/atomone/x/gov/keeper"
+)
+
+// Raw gov params read from atomone-1 state through abci_query path="/store/gov/key",
+// data=0x30, at heights inside each params layout era.
+const (
+	// height 749400: v1.0.0 state, before the dynamic quorum existed
+	paramsPreV3 = "ChMKBnVhdG9uZRIJNTEyMDAwMDAwEgQIgOpJGgQIgN9uIhQwLjI1MDAwMDAwMDAwMDAwMDAwMCoUMC42NjcwMDAwMDAwMDAwMDAwMDA6FDAuMTAwMDAwMDAwMDAwMDAwMDAwcAF6FDAuMDEwMDAwMDAwMDAwMDAwMDAwggEUMC4yNTAwMDAwMDAwMDAwMDAwMDCKARQwLjkwMDAwMDAwMDAwMDAwMDAwMJIBFDAuMjUwMDAwMDAwMDAwMDAwMDAwmgEUMC45MDAwMDAwMDAwMDAwMDAwMDCiAQQIgLxpqgEECICjBQ=="
+	// height 6085557: v3 state, atomone.gov.v1 layout with quorum ranges
+	paramsV3 = "ChMKBnVhdG9uZRIJNTEyMDAwMDAwEgQIgOpJGgQIgN9uIhQwLjI1MDAwMDAwMDAwMDAwMDAwMCoUMC42NjcwMDAwMDAwMDAwMDAwMDA6FDAuMTAwMDAwMDAwMDAwMDAwMDAwcAF6FDAuMDEwMDAwMDAwMDAwMDAwMDAwggEUMC4yNTAwMDAwMDAwMDAwMDAwMDCKARQwLjkwMDAwMDAwMDAwMDAwMDAwMJIBFDAuMjUwMDAwMDAwMDAwMDAwMDAwmgEUMC45MDAwMDAwMDAwMDAwMDAwMDCiAQQIgLxpqgEECICjBboBSgoSCgZ1YXRvbmUSCDEwMDAwMDAwEgQIgPUkGAIiFDAuMDUwMDAwMDAwMDAwMDAwMDAwKhQwLjAyNTAwMDAwMDAwMDAwMDAwMDACwgFIChAKBnVhdG9uZRIGMTAwMDAwEgQIgKMFGAUiFDAuMDEwMDAwMDAwMDAwMDAwMDAwKhQwLjAwNTAwMDAwMDAwMDAwMDAwMDACygEUMC44MDAwMDAwMDAwMDAwMDAwMDDSASwKFDAuNTAwMDAwMDAwMDAwMDAwMDAwEhQwLjEwMDAwMDAwMDAwMDAwMDAwMNoBLAoUMC41MDAwMDAwMDAwMDAwMDAwMDASFDAuMTAwMDAwMDAwMDAwMDAwMDAw4gEsChQwLjUwMDAwMDAwMDAwMDAwMDAwMBIUMC4xMDAwMDAwMDAwMDAwMDAwMDA="
+	// height 10276000: v4 state, cosmos.gov.v1 layout written by the v4 migration
+	paramsV4 = "EgQIgOpJGgQIgN9uKhQwLjY2NzAwMDAwMDAwMDAwMDAwMHABggEUMC4wMTAwMDAwMDAwMDAwMDAwMDCSARQwLjkwMDAwMDAwMDAwMDAwMDAwMKIBFDAuOTAwMDAwMDAwMDAwMDAwMDAwqgEECIC8abIBBAiAowXCAUsKEwoGdWF0b25lEgk1MTIwMDAwMDASBAiA9SQYAiIUMC4wNTAwMDAwMDAwMDAwMDAwMDAqFDAuMDI1MDAwMDAwMDAwMDAwMDAwMALKAUoKEgoGdWF0b25lEgg1MTIwMDAwMBIECICjBRgFIhQwLjAxMDAwMDAwMDAwMDAwMDAwMCoUMC4wMDUwMDAwMDAwMDAwMDAwMDAwAtIBFDAuODAwMDAwMDAwMDAwMDAwMDAw2gEsChQwLjUwMDAwMDAwMDAwMDAwMDAwMBIUMC4xMDAwMDAwMDAwMDAwMDAwMDDiASwKFDAuNTAwMDAwMDAwMDAwMDAwMDAwEhQwLjEwMDAwMDAwMDAwMDAwMDAwMOoBLAoUMC41MDAwMDAwMDAwMDAwMDAwMDASFDAuMTAwMDAwMDAwMDAwMDAwMDAw8gEFCIDUkwH6AQsxMDAwMDAwMDAwMA=="
+)
+
+func fixture(t *testing.T, b64 string) []byte {
+	t.Helper()
+	b, err := base64.StdEncoding.DecodeString(b64)
+	require.NoError(t, err)
+	return b
+}
+
+func newCodec() codec.Codec {
+	return codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+}
+
+func TestIsLegacyParamsLayout(t *testing.T) {
+	require.True(t, keeper.IsLegacyParamsLayout(fixture(t, paramsPreV3)))
+	require.True(t, keeper.IsLegacyParamsLayout(fixture(t, paramsV3)))
+	require.False(t, keeper.IsLegacyParamsLayout(fixture(t, paramsV4)))
+
+	current, err := newCodec().Marshal(&sdkv1.Params{})
+	require.NoError(t, err)
+	require.False(t, keeper.IsLegacyParamsLayout(current))
+	defaults := sdkv1.DefaultParams()
+	current, err = newCodec().Marshal(&defaults)
+	require.NoError(t, err)
+	require.False(t, keeper.IsLegacyParamsLayout(current))
+	require.False(t, keeper.IsLegacyParamsLayout([]byte{0xff}))
+}
+
+func TestParamsValueCodecDecodesPreV3State(t *testing.T) {
+	params, err := keeper.ParamsValueCodec(newCodec()).Decode(fixture(t, paramsPreV3))
+	require.NoError(t, err)
+
+	// Values as the chain stored them at genesis; every field from 15 upwards
+	// would otherwise land one field off.
+	require.Equal(t, "0.250000000000000000", params.Quorum)
+	require.Equal(t, "0.667000000000000000", params.Threshold)
+	require.Equal(t, "0.010000000000000000", params.MinDepositRatio)
+	require.Equal(t, "0.250000000000000000", params.ConstitutionAmendmentQuorum)
+	require.Equal(t, "0.900000000000000000", params.ConstitutionAmendmentThreshold)
+	require.Equal(t, "0.250000000000000000", params.LawQuorum)
+	require.Equal(t, "0.900000000000000000", params.LawThreshold)
+	require.NotNil(t, params.QuorumTimeout)
+	require.Equal(t, float64(20*24*3600), params.QuorumTimeout.Seconds())
+	require.NotNil(t, params.MaxVotingPeriodExtension)
+	require.Equal(t, float64(24*3600), params.MaxVotingPeriodExtension.Seconds())
+	require.Equal(t, uint64(0), params.QuorumCheckCount)
+
+	// No dynamic quorum yet: the ranges pin the static quorum the chain applied
+	require.Equal(t, &sdkv1.QuorumRange{Min: "0.250000000000000000", Max: "0.250000000000000000"}, params.QuorumRange)
+	require.Equal(t, &sdkv1.QuorumRange{Min: "0.250000000000000000", Max: "0.250000000000000000"}, params.ConstitutionAmendmentQuorumRange)
+	require.Equal(t, &sdkv1.QuorumRange{Min: "0.250000000000000000", Max: "0.250000000000000000"}, params.LawQuorumRange)
+}
+
+func TestParamsValueCodecDecodesV3State(t *testing.T) {
+	cdc := newCodec()
+	// The current layout cannot read these bytes at all (field 23 changed wire type)
+	_, err := codec.CollValue[sdkv1.Params](cdc).Decode(fixture(t, paramsV3))
+	require.Error(t, err)
+
+	params, err := keeper.ParamsValueCodec(cdc).Decode(fixture(t, paramsV3))
+	require.NoError(t, err)
+	require.Equal(t, "0.250000000000000000", params.Quorum)
+	require.Equal(t, "0.010000000000000000", params.MinDepositRatio)
+	require.Equal(t, "0.900000000000000000", params.LawThreshold)
+	require.Equal(t, "0.800000000000000000", params.BurnDepositNoThreshold)
+	require.NotNil(t, params.MinDepositThrottler)
+	// Ranges written by the v3 upgrade are kept as stored, not replaced
+	require.Equal(t, &sdkv1.QuorumRange{Min: "0.100000000000000000", Max: "0.500000000000000000"}, params.QuorumRange)
+}
+
+func TestParamsValueCodecKeepsCurrentLayout(t *testing.T) {
+	cdc := newCodec()
+	want, err := codec.CollValue[sdkv1.Params](cdc).Decode(fixture(t, paramsV4))
+	require.NoError(t, err)
+	got, err := keeper.ParamsValueCodec(cdc).Decode(fixture(t, paramsV4))
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	// Encoding is unchanged: what the codec writes, the plain codec reads back
+	defaults := sdkv1.DefaultParams()
+	encoded, err := keeper.ParamsValueCodec(cdc).Encode(defaults)
+	require.NoError(t, err)
+	roundTrip, err := codec.CollValue[sdkv1.Params](cdc).Decode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, defaults, roundTrip)
+}


### PR DESCRIPTION
## Description

Closes: none. Found while indexing atomone-1 from genesis against an archive node.

The v4 upgrade moved gov params to the `cosmos.gov.v1` layout of the SDK fork, which renumbers every field from 15 upwards by one. A historical query runs the current binary against pre-migration state, so params written by v1, v2 and v3 are read with the wrong type:

| State era | Heights | What the current type reads |
|---|---|---|
| v1, v2 | below 5,902,000 | decodes without error, one field off: `min_deposit_ratio` dropped, every later field shifted, quorum ranges nil |
| v3 | 5,902,000 to 9,549,999 | fails: `wrong wireType = 2 for field QuorumCheckCount` (legacy field 23 is a message, the new field 23 a varint) |

The nil quorum ranges then panic in `GetQuorum`. On atomone-1 every `TallyResult` and `Params` query at a height inside a proposal's voting period before the v4 upgrade returns ABCI code 111222 or 18. Reproduction with nothing but curl:

```
https://atomone-rpc-history.infra.allinbits.vip/abci_query?path=%22/atomone.gov.v1.Query/TallyResult%22&data=0x0801&height=749400
```

This change gives the gov keeper's `Params` collection a layout-aware codec (`x/gov/keeper/params_codec.go`), installed in `app/keepers/keepers.go` right after the keeper is built:

- the pre-v4 layout is recognised by its field 15 marker (`min_deposit_ratio`), which the current layout never writes;
- legacy bytes are decoded with the retained `atomone.gov.v1` type and converted with the existing `ConvertAtomOneParamsToSDK`, the same path the v4 migration used;
- state that predates the dynamic quorum gets quorum ranges pinned to its static quorum, so the dynamic-quorum code returns exactly the quorum the chain applied then;
- encoding and current-layout decoding are unchanged.

The tests decode the actual params bytes read from atomone-1 state at heights 749,400, 6,085,557 and 10,276,000 (`abci_query path="/store/gov/key" data=0x30`).

The SDK fork needs the companion change https://github.com/atomone-hub/atomone-sdk/pull/114, which makes the quorum getters tolerate a missing participation EMA; with this codec alone, pre-v3 state still panics on the nil EMA. Once that is released the `replace` in `go.mod` should be bumped on this branch.

---

### Author Checklist

I have...

* [x] Included the correct type prefix in the PR title
* [x] Added `!` to the type prefix if API, client, or state breaking change (not applicable: query-side decoding only; stored state and its encoding are unchanged)
* [x] Targeted the correct branch (`main`)
* [x] Provided a link to the relevant issue or specification (no issue; reproduction in the description)
* [x] Followed the guidelines for building SDK modules
* [x] Included the necessary unit and integration tests
* [x] Added a changelog entry (in the `Unreleased` section of `CHANGELOG.md`, per CONTRIBUTING)
* [x] Included comments for documenting Go code
* [x] Updated the relevant documentation or specification (not applicable)
* [x] Reviewed "Files changed" and left comments if necessary
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct type prefix in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
