### PR TITLE
fix(10-gno): bind validator addresses to pubkeys and bound PartSetHeader.Total during conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,22 @@
 ### BUG FIXES
 
 - Prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions in `x/photon` [#352](https://github.com/atomone-hub/atomone/pull/352)
-- Require `10-gno` validator addresses to be derived from their public keys during conversion, matching native gno validation, and key the duplicate-address check on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
-- Bound `PartSetHeader.Total` and validate the parts hash when converting `10-gno` headers and commits, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values are rejected with an error instead of panicking during vote sign-bytes canonicalization [#367](https://github.com/atomone-hub/atomone/pull/367)
 
 ### DEPENDENCIES
 
 ### FEATURES
 
 ### STATE BREAKING
+
+- Require `10-gno` validator addresses to be derived from their public keys during conversion, matching native gno validation, and key the duplicate-address check on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
+- Bound `PartSetHeader.Total` and validate the parts hash when converting `10-gno` headers and commits, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values are rejected with an error instead of panicking during vote sign-bytes canonicalization [#367](https://github.com/atomone-hub/atomone/pull/367)
+  > Both `10-gno` changes only alter behavior for malformed client messages: a header whose
+  > validator addresses are not derived from their public keys was previously accepted and is
+  > now rejected, and a header whose parts-header total is out of range previously failed with
+  > a recovered panic and now fails with a typed error. Legitimate gno headers are unaffected.
+  > Because the transaction error code and gas used feed into the results hash, nodes running
+  > different versions would diverge if such a message were submitted, so these changes must
+  > ship in a coordinated upgrade rather than a patch release nodes adopt independently.
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### BUG FIXES
 
 - Prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions in `x/photon` [#352](https://github.com/atomone-hub/atomone/pull/352)
+- Require `10-gno` validator addresses to be derived from their public keys during conversion, matching native gno validation, and key the duplicate-address check on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 
 ### STATE BREAKING
 
-- Require `10-gno` validator addresses to be derived from their public keys, matching native gno validation, and deduplicate validators on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
-- Bound `10-gno` `PartSetHeader.Total` and validate the parts hash during conversion, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values return an error instead of panicking [#367](https://github.com/atomone-hub/atomone/pull/367)
+- fix(10-gno): bind validator addresses to pubkeys and bound PartSetHeader.Total during conversion [#367](https://github.com/atomone-hub/atomone/pull/367)
 
 > **Note:** both `10-gno` changes only affect malformed client messages, which are now rejected with an error where they were previously either accepted (unbound validator addresses) or failed with a recovered panic (out-of-range parts total). Legitimate gno headers are unaffected. Since the transaction error code and gas used are part of the results hash, nodes on different versions would diverge on such a message, so these changes require a coordinated upgrade.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Prevent bundling the wildcard symbol in `TxFeeExceptions` with other exceptions in `x/photon` [#352](https://github.com/atomone-hub/atomone/pull/352)
 - Require `10-gno` validator addresses to be derived from their public keys during conversion, matching native gno validation, and key the duplicate-address check on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
+- Bound `PartSetHeader.Total` and validate the parts hash when converting `10-gno` headers and commits, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values are rejected with an error instead of panicking during vote sign-bytes canonicalization [#367](https://github.com/atomone-hub/atomone/pull/367)
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,10 @@
 
 ### STATE BREAKING
 
-- Require `10-gno` validator addresses to be derived from their public keys during conversion, matching native gno validation, and key the duplicate-address check on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
-- Bound `PartSetHeader.Total` and validate the parts hash when converting `10-gno` headers and commits, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values are rejected with an error instead of panicking during vote sign-bytes canonicalization [#367](https://github.com/atomone-hub/atomone/pull/367)
-  > Both `10-gno` changes only alter behavior for malformed client messages: a header whose
-  > validator addresses are not derived from their public keys was previously accepted and is
-  > now rejected, and a header whose parts-header total is out of range previously failed with
-  > a recovered panic and now fails with a typed error. Legitimate gno headers are unaffected.
-  > Because the transaction error code and gas used feed into the results hash, nodes running
-  > different versions would diverge if such a message were submitted, so these changes must
-  > ship in a coordinated upgrade rather than a patch release nodes adopt independently.
+- Require `10-gno` validator addresses to be derived from their public keys, matching native gno validation, and deduplicate validators on the parsed address [#367](https://github.com/atomone-hub/atomone/pull/367)
+- Bound `10-gno` `PartSetHeader.Total` and validate the parts hash during conversion, mirroring gno's `PartSetHeader.ValidateBasic`, so out-of-range values return an error instead of panicking [#367](https://github.com/atomone-hub/atomone/pull/367)
+
+> **Note:** both `10-gno` changes only affect malformed client messages, which are now rejected with an error where they were previously either accepted (unbound validator addresses) or failed with a recovered panic (out-of-range parts total). Legitimate gno headers are unaffected. Since the transaction error code and gas used are part of the results hash, nodes on different versions would diverge on such a message, so these changes require a coordinated upgrade.
 
 ### IMPROVEMENTS
 

--- a/modules/10-gno/helpers.go
+++ b/modules/10-gno/helpers.go
@@ -1,6 +1,8 @@
 package gno
 
 import (
+	"math"
+
 	bfttypes "github.com/gnolang/gno/tm2/pkg/bft/types"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
@@ -146,6 +148,11 @@ func ConvertToGnoCommit(commit *Commit) (*bfttypes.Commit, error) {
 		if err != nil {
 			return nil, errorsmod.Wrapf(err, "invalid block ID in precommit %d", i)
 		}
+		// SignedMsgType is a byte. Reject anything the conversion would truncate,
+		// so gno's own precommit type check sees the actual wire value.
+		if sig.Type > math.MaxUint8 {
+			return nil, errorsmod.Wrapf(clienttypes.ErrInvalidHeader, "precommit %d type %d out of range", i, sig.Type)
+		}
 		gnoCommit.Precommits[i] = &bfttypes.CommitSig{
 			ValidatorIndex: int(sig.ValidatorIndex),
 			Signature:      sig.Signature,
@@ -242,8 +249,8 @@ func ConvertToGnoSignedHeader(signedHeader *SignedHeader) (*bfttypes.SignedHeade
 }
 
 // ConvertToGnoBlockID converts a protobuf BlockID to a bfttypes.BlockID. A nil block
-// ID or parts header converts to the zero value; callers that require them to be
-// present should call ValidateBasic on the result.
+// ID or parts header converts to the zero value. Callers that require a present block
+// ID should check IsComplete on the result, since ValidateBasic accepts the zero value.
 func ConvertToGnoBlockID(blockID *BlockID) (bfttypes.BlockID, error) {
 	if blockID == nil {
 		return bfttypes.BlockID{}, nil
@@ -262,7 +269,7 @@ func ConvertToGnoBlockID(blockID *BlockID) (bfttypes.BlockID, error) {
 // enforcing the bounds gno's PartSetHeader.ValidateBasic applies. A nil parts header
 // converts to the zero value.
 //
-// The vendored CanonicalizePartSetHeader panics on a Total outside the uint32 range
+// gno's CanonicalizePartSetHeader panics on a Total outside the uint32 range
 // while computing vote sign bytes, and relies on PartSetHeader.ValidateBasic having
 // run first. None of the light client's ValidateBasic paths reach that check, so a
 // relayer-supplied Total has to be bounded here, at conversion, before it can reach

--- a/modules/10-gno/helpers.go
+++ b/modules/10-gno/helpers.go
@@ -40,8 +40,6 @@ func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, err
 		Proposer:   nil,
 	}
 
-	// Keyed on the parsed address rather than the raw string: bech32 decoding is
-	// case-insensitive, so distinct strings can denote the same address.
 	seen := make(map[crypto.Address]struct{}, len(valSet.Validators))
 	totalVotingPower := int64(0)
 	for i, val := range valSet.Validators {

--- a/modules/10-gno/helpers.go
+++ b/modules/10-gno/helpers.go
@@ -11,9 +11,10 @@ import (
 )
 
 // ConvertToGnoValidatorSet converts a protobuf ValidatorSet to a bfttypes.ValidatorSet.
-// It returns an error if any validator has a non-ed25519 public key, an invalid address,
-// non-positive or out-of-bounds voting power, if any address is duplicated, if the total
-// voting power exceeds the allowed bound, or if the resulting validator set is nil or empty.
+// It returns an error if any validator has a non-ed25519 or malformed public key, an
+// invalid address, an address that is not derived from its public key, non-positive or
+// out-of-bounds voting power, if any address is duplicated, if the total voting power
+// exceeds the allowed bound, or if the resulting validator set is nil or empty.
 //
 // Unlike Gno's NewValidatorSet constructor (which sorts validators by address), this function
 // preserves the input order because GetByIndex-based commit verification relies on the proto
@@ -22,6 +23,11 @@ import (
 // reordering the set. Skipping these checks would allow a relayer-supplied set with negative
 // voting power to produce a negative total, making the +2/3 commit threshold negative and
 // satisfiable by a single signature.
+//
+// The address-to-pubkey binding matters because Validator.Bytes() (and therefore
+// ValidatorSet.Hash()) excludes the address, and commit sign bytes exclude the validator
+// address and index. Without the binding, a relayer could attach distinct addresses to a
+// single public key and have one signature counted in several validator slots.
 func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, error) {
 	if valSet == nil {
 		return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "validator set is nil")
@@ -32,21 +38,36 @@ func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, err
 		Proposer:   nil,
 	}
 
-	seen := make(map[string]struct{}, len(valSet.Validators))
+	// Keyed on the parsed address rather than the raw string: bech32 decoding is
+	// case-insensitive, so distinct strings can denote the same address.
+	seen := make(map[crypto.Address]struct{}, len(valSet.Validators))
 	totalVotingPower := int64(0)
 	for i, val := range valSet.Validators {
-		key := val.PubKey
-		if key.GetEd25519() == nil {
+		if val == nil {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "validator at index %d is nil", i)
+		}
+		keyBytes := val.PubKey.GetEd25519()
+		if keyBytes == nil {
 			return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "validator pubkey is not ed25519")
 		}
+		// Converting a slice to [32]byte panics when the slice is shorter, so
+		// check the length before building the key.
+		if len(keyBytes) != ed25519.PubKeyEd25519Size {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "validator pubkey has length %d, expected %d", len(keyBytes), ed25519.PubKeyEd25519Size)
+		}
+		pubKey := ed25519.PubKeyEd25519(keyBytes)
 		address, err := crypto.AddressFromString(val.Address)
 		if err != nil {
 			return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "invalid validator address")
 		}
-		if _, ok := seen[val.Address]; ok {
+		// Same binding Gno enforces in its own validator set constructor.
+		if address != pubKey.Address() {
+			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "validator address %s does not match pubkey", val.Address)
+		}
+		if _, ok := seen[address]; ok {
 			return nil, errorsmod.Wrapf(ErrInvalidValidatorSet, "duplicate validator address %s", val.Address)
 		}
-		seen[val.Address] = struct{}{}
+		seen[address] = struct{}{}
 
 		// Reject non-positive voting power: a real Gno validator set never contains
 		// negative- or zero-power members (zero-power entries are removed during updates).
@@ -64,7 +85,7 @@ func ConvertToGnoValidatorSet(valSet *ValidatorSet) (*bfttypes.ValidatorSet, err
 
 		gnoValset.Validators[i] = &bfttypes.Validator{
 			Address:          address,
-			PubKey:           ed25519.PubKeyEd25519(key.GetEd25519()),
+			PubKey:           pubKey,
 			VotingPower:      val.VotingPower,
 			ProposerPriority: val.ProposerPriority,
 		}

--- a/modules/10-gno/helpers.go
+++ b/modules/10-gno/helpers.go
@@ -113,13 +113,14 @@ func ConvertToGnoCommit(commit *Commit) (*bfttypes.Commit, error) {
 		return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "commit block ID parts header is nil")
 	}
 
+	partsHeader, err := convertPartSetHeader(commit.BlockId.PartsHeader)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid commit block ID")
+	}
 	gnoCommit := bfttypes.Commit{
 		BlockID: bfttypes.BlockID{
-			Hash: commit.BlockId.Hash,
-			PartsHeader: bfttypes.PartSetHeader{
-				Total: int(commit.BlockId.PartsHeader.Total),
-				Hash:  commit.BlockId.PartsHeader.Hash,
-			},
+			Hash:        commit.BlockId.Hash,
+			PartsHeader: partsHeader,
 		},
 		Precommits: make([]*bfttypes.CommitSig, len(commit.Precommits)),
 	}
@@ -141,15 +142,16 @@ func ConvertToGnoCommit(commit *Commit) (*bfttypes.Commit, error) {
 		if err != nil {
 			return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "invalid validator address")
 		}
+		sigPartsHeader, err := convertPartSetHeader(sig.BlockId.PartsHeader)
+		if err != nil {
+			return nil, errorsmod.Wrapf(err, "invalid block ID in precommit %d", i)
+		}
 		gnoCommit.Precommits[i] = &bfttypes.CommitSig{
 			ValidatorIndex: int(sig.ValidatorIndex),
 			Signature:      sig.Signature,
 			BlockID: bfttypes.BlockID{
-				Hash: sig.BlockId.Hash,
-				PartsHeader: bfttypes.PartSetHeader{
-					Total: int(sig.BlockId.PartsHeader.Total),
-					Hash:  sig.BlockId.PartsHeader.Hash,
-				},
+				Hash:        sig.BlockId.Hash,
+				PartsHeader: sigPartsHeader,
 			},
 			Type:             bfttypes.SignedMsgType(sig.Type),
 			Height:           sig.Height,
@@ -188,6 +190,10 @@ func ConvertToGnoHeader(header *GnoHeader) (*bfttypes.Header, error) {
 	if err != nil {
 		return nil, errorsmod.Wrap(clienttypes.ErrInvalidHeader, "invalid validator address")
 	}
+	lastPartsHeader, err := convertPartSetHeader(header.LastBlockId.PartsHeader)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid header last block ID")
+	}
 	gnoHeader := bfttypes.Header{
 		Version:    header.Version,
 		ChainID:    header.ChainId,
@@ -197,11 +203,8 @@ func ConvertToGnoHeader(header *GnoHeader) (*bfttypes.Header, error) {
 		TotalTxs:   header.TotalTxs,
 		AppVersion: header.AppVersion,
 		LastBlockID: bfttypes.BlockID{
-			Hash: header.LastBlockId.Hash,
-			PartsHeader: bfttypes.PartSetHeader{
-				Total: int(header.LastBlockId.PartsHeader.Total),
-				Hash:  header.LastBlockId.PartsHeader.Hash,
-			},
+			Hash:        header.LastBlockId.Hash,
+			PartsHeader: lastPartsHeader,
 		},
 		LastCommitHash:     header.LastCommitHash,
 		DataHash:           dataHash,
@@ -238,21 +241,44 @@ func ConvertToGnoSignedHeader(signedHeader *SignedHeader) (*bfttypes.SignedHeade
 	}, nil
 }
 
-// ConvertToGnoBlockID converts a protobuf BlockID to a bfttypes.BlockID.
-func ConvertToGnoBlockID(blockID *BlockID) bfttypes.BlockID {
+// ConvertToGnoBlockID converts a protobuf BlockID to a bfttypes.BlockID. A nil block
+// ID or parts header converts to the zero value; callers that require them to be
+// present should call ValidateBasic on the result.
+func ConvertToGnoBlockID(blockID *BlockID) (bfttypes.BlockID, error) {
 	if blockID == nil {
-		return bfttypes.BlockID{}
+		return bfttypes.BlockID{}, nil
 	}
-	if blockID.PartsHeader == nil {
-		return bfttypes.BlockID{
-			Hash: blockID.Hash,
-		}
+	partsHeader, err := convertPartSetHeader(blockID.PartsHeader)
+	if err != nil {
+		return bfttypes.BlockID{}, err
 	}
 	return bfttypes.BlockID{
-		Hash: blockID.Hash,
-		PartsHeader: bfttypes.PartSetHeader{
-			Total: int(blockID.PartsHeader.Total),
-			Hash:  blockID.PartsHeader.Hash,
-		},
+		Hash:        blockID.Hash,
+		PartsHeader: partsHeader,
+	}, nil
+}
+
+// convertPartSetHeader converts a protobuf PartSetHeader to a bfttypes.PartSetHeader,
+// enforcing the bounds gno's PartSetHeader.ValidateBasic applies. A nil parts header
+// converts to the zero value.
+//
+// The vendored CanonicalizePartSetHeader panics on a Total outside the uint32 range
+// while computing vote sign bytes, and relies on PartSetHeader.ValidateBasic having
+// run first. None of the light client's ValidateBasic paths reach that check, so a
+// relayer-supplied Total has to be bounded here, at conversion, before it can reach
+// commit verification.
+func convertPartSetHeader(psh *PartSetHeader) (bfttypes.PartSetHeader, error) {
+	if psh == nil {
+		return bfttypes.PartSetHeader{}, nil
 	}
+	if psh.Total < 0 || psh.Total > bfttypes.MaxBlockPartsCount {
+		return bfttypes.PartSetHeader{}, errorsmod.Wrapf(clienttypes.ErrInvalidHeader, "parts header total %d out of range [0, %d]", psh.Total, bfttypes.MaxBlockPartsCount)
+	}
+	if err := bfttypes.ValidateHash(psh.Hash); err != nil {
+		return bfttypes.PartSetHeader{}, errorsmod.Wrapf(clienttypes.ErrInvalidHeader, "invalid parts header hash: %v", err)
+	}
+	return bfttypes.PartSetHeader{
+		Total: int(psh.Total),
+		Hash:  psh.Hash,
+	}, nil
 }

--- a/modules/10-gno/helpers_test.go
+++ b/modules/10-gno/helpers_test.go
@@ -142,7 +142,8 @@ func TestConvertToGnoValidatorSet_RejectsMalformedSets(t *testing.T) {
 		// Shape of a forged set that reuses a single key, and therefore a
 		// single commit signature, across several validator slots. Every
 		// address is syntactically valid and distinct; only the binding to
-		// the pubkey is wrong.
+		// the pubkey is wrong. The first entry is legitimately bound, so the
+		// converter must stop at the second and name it.
 		valC, _ := createTestValidator(10)
 		forged := []*Validator{
 			createTestValidatorWithKey(100, keyA),
@@ -152,6 +153,7 @@ func TestConvertToGnoValidatorSet_RejectsMalformedSets(t *testing.T) {
 		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: forged})
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+		require.Contains(t, err.Error(), valB.Address)
 	})
 
 	t.Run("duplicate address differing only in case", func(t *testing.T) {
@@ -257,7 +259,7 @@ func TestConvertToGnoHeader_AppVersion(t *testing.T) {
 
 // TestConvertPartSetHeader_Bounds ensures every converter rejects a PartSetHeader whose
 // Total lies outside gno's [0, MaxBlockPartsCount] bound, or whose hash has the wrong
-// size, instead of forwarding it. The vendored CanonicalizePartSetHeader panics on a
+// size, instead of forwarding it. gno's CanonicalizePartSetHeader panics on a
 // Total outside the uint32 range when computing vote sign bytes, and nothing in the
 // ValidateBasic chain caps Total, so the bound must be enforced at conversion.
 func TestConvertPartSetHeader_Bounds(t *testing.T) {
@@ -271,34 +273,38 @@ func TestConvertPartSetHeader_Bounds(t *testing.T) {
 	blockID := func(p *PartSetHeader) *BlockID {
 		return &BlockID{Hash: make([]byte, 32), PartsHeader: p}
 	}
-	// One conversion per cast site.
-	converters := map[string]func(*PartSetHeader) error{
-		"commit block id": func(p *PartSetHeader) error {
+	// One conversion per cast site, in a slice so subtest order is stable.
+	converters := []struct {
+		name    string
+		convert func(*PartSetHeader) error
+	}{
+		{"commit block id", func(p *PartSetHeader) error {
 			_, err := ConvertToGnoCommit(&Commit{BlockId: blockID(p), Precommits: signed.Commit.Precommits})
 			return err
-		},
-		"precommit block id": func(p *PartSetHeader) error {
+		}},
+		{"precommit block id", func(p *PartSetHeader) error {
 			sig := *signed.Commit.Precommits[0]
 			sig.BlockId = blockID(p)
 			_, err := ConvertToGnoCommit(&Commit{BlockId: signed.Commit.BlockId, Precommits: []*CommitSig{&sig}})
 			return err
-		},
-		"header last block id": func(p *PartSetHeader) error {
+		}},
+		{"header last block id", func(p *PartSetHeader) error {
 			h := createTestGnoHeader(testChainID, 10, time.Now().UTC(), make([]byte, 32), proposer)
 			h.LastBlockId = blockID(p)
 			_, err := ConvertToGnoHeader(h)
 			return err
-		},
-		"block id": func(p *PartSetHeader) error {
+		}},
+		{"block id", func(p *PartSetHeader) error {
 			_, err := ConvertToGnoBlockID(blockID(p))
 			return err
-		},
+		}},
 	}
 
 	badTotals := []int64{-1, bfttypes.MaxBlockPartsCount + 1, math.MaxUint32 + 1, math.MaxInt64}
 	goodTotals := []int64{0, 1, bfttypes.MaxBlockPartsCount}
 
-	for name, convert := range converters {
+	for _, c := range converters {
+		name, convert := c.name, c.convert
 		for _, total := range badTotals {
 			t.Run(fmt.Sprintf("%s rejects total %d", name, total), func(t *testing.T) {
 				var err error
@@ -327,4 +333,27 @@ func TestConvertPartSetHeader_Bounds(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, bfttypes.PartSetHeader{}, id.PartsHeader)
 	})
+}
+
+// TestConvertToGnoCommit_RejectsOutOfRangePrecommitType ensures a precommit Type that
+// does not fit gno's byte-sized SignedMsgType is rejected instead of being truncated
+// by the conversion, which would otherwise let a wire value such as 258 pass gno's
+// precommit type check as PrecommitType.
+func TestConvertToGnoCommit_RejectsOutOfRangePrecommitType(t *testing.T) {
+	valSet, privKeys := createTestValidatorSet(1, 100)
+	signed := createTestSignedHeader(testChainID, 10, time.Now().UTC(), valSet, privKeys)
+
+	// Sanity: the narrowing conversion alone would map this to PrecommitType.
+	wireType := uint32(bfttypes.PrecommitType) + 256
+	require.Equal(t, bfttypes.PrecommitType, bfttypes.SignedMsgType(wireType))
+
+	sig := *signed.Commit.Precommits[0]
+	sig.Type = wireType
+	_, err := ConvertToGnoCommit(&Commit{BlockId: signed.Commit.BlockId, Precommits: []*CommitSig{&sig}})
+	require.ErrorIs(t, err, clienttypes.ErrInvalidHeader)
+	require.Contains(t, err.Error(), "type")
+
+	// The in-range value is still accepted.
+	_, err = ConvertToGnoCommit(signed.Commit)
+	require.NoError(t, err)
 }

--- a/modules/10-gno/helpers_test.go
+++ b/modules/10-gno/helpers_test.go
@@ -2,6 +2,8 @@ package gno
 
 import (
 	"crypto/rand"
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmtcrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
 )
 
 // TestConvertToGnoCommit_AbsentValidators tests that ConvertToGnoCommit correctly
@@ -250,4 +253,78 @@ func TestConvertToGnoHeader_AppVersion(t *testing.T) {
 
 	require.NotEqual(t, hashWith, hashWithout,
 		"header hash must differ when AppVersion changes, proving it participates in the Merkle tree")
+}
+
+// TestConvertPartSetHeader_Bounds ensures every converter rejects a PartSetHeader whose
+// Total lies outside gno's [0, MaxBlockPartsCount] bound, or whose hash has the wrong
+// size, instead of forwarding it. The vendored CanonicalizePartSetHeader panics on a
+// Total outside the uint32 range when computing vote sign bytes, and nothing in the
+// ValidateBasic chain caps Total, so the bound must be enforced at conversion.
+func TestConvertPartSetHeader_Bounds(t *testing.T) {
+	valSet, privKeys := createTestValidatorSet(1, 100)
+	signed := createTestSignedHeader(testChainID, 10, time.Now().UTC(), valSet, privKeys)
+	proposer := valSet.Validators[0].Address
+
+	psh := func(total int64, hashLen int) *PartSetHeader {
+		return &PartSetHeader{Total: total, Hash: make([]byte, hashLen)}
+	}
+	blockID := func(p *PartSetHeader) *BlockID {
+		return &BlockID{Hash: make([]byte, 32), PartsHeader: p}
+	}
+	// One conversion per cast site.
+	converters := map[string]func(*PartSetHeader) error{
+		"commit block id": func(p *PartSetHeader) error {
+			_, err := ConvertToGnoCommit(&Commit{BlockId: blockID(p), Precommits: signed.Commit.Precommits})
+			return err
+		},
+		"precommit block id": func(p *PartSetHeader) error {
+			sig := *signed.Commit.Precommits[0]
+			sig.BlockId = blockID(p)
+			_, err := ConvertToGnoCommit(&Commit{BlockId: signed.Commit.BlockId, Precommits: []*CommitSig{&sig}})
+			return err
+		},
+		"header last block id": func(p *PartSetHeader) error {
+			h := createTestGnoHeader(testChainID, 10, time.Now().UTC(), make([]byte, 32), proposer)
+			h.LastBlockId = blockID(p)
+			_, err := ConvertToGnoHeader(h)
+			return err
+		},
+		"block id": func(p *PartSetHeader) error {
+			_, err := ConvertToGnoBlockID(blockID(p))
+			return err
+		},
+	}
+
+	badTotals := []int64{-1, bfttypes.MaxBlockPartsCount + 1, math.MaxUint32 + 1, math.MaxInt64}
+	goodTotals := []int64{0, 1, bfttypes.MaxBlockPartsCount}
+
+	for name, convert := range converters {
+		for _, total := range badTotals {
+			t.Run(fmt.Sprintf("%s rejects total %d", name, total), func(t *testing.T) {
+				var err error
+				require.NotPanics(t, func() { err = convert(psh(total, 32)) })
+				require.ErrorIs(t, err, clienttypes.ErrInvalidHeader)
+				require.Contains(t, err.Error(), "parts header total")
+			})
+		}
+		for _, total := range goodTotals {
+			t.Run(fmt.Sprintf("%s accepts total %d", name, total), func(t *testing.T) {
+				require.NoError(t, convert(psh(total, 32)))
+			})
+		}
+		t.Run(name+" rejects wrong hash size", func(t *testing.T) {
+			err := convert(psh(1, 31))
+			require.ErrorIs(t, err, clienttypes.ErrInvalidHeader)
+			require.Contains(t, err.Error(), "parts header hash")
+		})
+		t.Run(name+" accepts empty hash", func(t *testing.T) {
+			require.NoError(t, convert(psh(0, 0)))
+		})
+	}
+
+	t.Run("nil parts header converts to zero value", func(t *testing.T) {
+		id, err := ConvertToGnoBlockID(&BlockID{Hash: make([]byte, 32)})
+		require.NoError(t, err)
+		require.Equal(t, bfttypes.PartSetHeader{}, id.PartsHeader)
+	})
 }

--- a/modules/10-gno/helpers_test.go
+++ b/modules/10-gno/helpers_test.go
@@ -2,6 +2,7 @@ package gno
 
 import (
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/gnolang/gno/tm2/pkg/crypto/ed25519"
 
 	"github.com/stretchr/testify/require"
+
+	cmtcrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 )
 
 // TestConvertToGnoCommit_AbsentValidators tests that ConvertToGnoCommit correctly
@@ -114,6 +117,67 @@ func TestConvertToGnoValidatorSet_RejectsMalformedSets(t *testing.T) {
 		half := createTestValidatorWithKey(bfttypes.MaxTotalVotingPower-1, keyA)
 		half2 := createTestValidatorWithKey(bfttypes.MaxTotalVotingPower-1, keyB)
 		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{half, half2}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("address not derived from pubkey", func(t *testing.T) {
+		// valB's address paired with valA's pubkey.
+		unbound := &Validator{Address: valB.Address, PubKey: valA.PubKey, VotingPower: 10}
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{unbound}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+		require.Contains(t, err.Error(), "does not match pubkey")
+
+		// Sanity check: Gno's own constructor also rejects this set.
+		require.Panics(t, func() {
+			bfttypes.NewValidatorSet([]*bfttypes.Validator{toBftValidator(unbound)})
+		})
+	})
+
+	t.Run("one pubkey under several distinct addresses", func(t *testing.T) {
+		// Shape of a forged set that reuses a single key, and therefore a
+		// single commit signature, across several validator slots. Every
+		// address is syntactically valid and distinct; only the binding to
+		// the pubkey is wrong.
+		valC, _ := createTestValidator(10)
+		forged := []*Validator{
+			createTestValidatorWithKey(100, keyA),
+			{Address: valB.Address, PubKey: valA.PubKey, VotingPower: 100},
+			{Address: valC.Address, PubKey: valA.PubKey, VotingPower: 100},
+		}
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: forged})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("duplicate address differing only in case", func(t *testing.T) {
+		// bech32 decoding is case-insensitive, so both strings denote the
+		// same address and the duplicate check must key on the parsed value.
+		upper := createTestValidatorWithKey(5, keyA)
+		upper.Address = strings.ToUpper(upper.Address)
+		_, err := ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, upper}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+		require.Contains(t, err.Error(), "duplicate")
+	})
+
+	t.Run("pubkey with invalid length is rejected without panicking", func(t *testing.T) {
+		short := createTestValidatorWithKey(10, keyA)
+		short.PubKey = &cmtcrypto.PublicKey{Sum: &cmtcrypto.PublicKey_Ed25519{Ed25519: []byte{1, 2, 3}}}
+		var err error
+		require.NotPanics(t, func() {
+			_, err = ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{short}})
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidValidatorSet)
+	})
+
+	t.Run("nil validator entry is rejected", func(t *testing.T) {
+		var err error
+		require.NotPanics(t, func() {
+			_, err = ConvertToGnoValidatorSet(&ValidatorSet{Validators: []*Validator{valA, nil}})
+		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrInvalidValidatorSet)
 	})

--- a/modules/10-gno/misbehaviour.go
+++ b/modules/10-gno/misbehaviour.go
@@ -89,12 +89,18 @@ func (misbehaviour Misbehaviour) ValidateBasic() error {
 		return errorsmod.Wrapf(clienttypes.ErrInvalidMisbehaviour, "Header1 height is less than Header2 height (%s < %s)", misbehaviour.Header1.GetHeight(), misbehaviour.Header2.GetHeight())
 	}
 
-	blockId1 := ConvertToGnoBlockID(misbehaviour.Header1.SignedHeader.Commit.BlockId)
-	if err := blockId1.ValidateBasic(); err != nil {
+	blockId1, err := ConvertToGnoBlockID(misbehaviour.Header1.SignedHeader.Commit.BlockId)
+	if err != nil {
 		return errorsmod.Wrap(err, "invalid block ID from header 1 in misbehaviour")
 	}
-	blockId2 := ConvertToGnoBlockID(misbehaviour.Header2.SignedHeader.Commit.BlockId)
-	if err := blockId2.ValidateBasic(); err != nil {
+	if err = blockId1.ValidateBasic(); err != nil {
+		return errorsmod.Wrap(err, "invalid block ID from header 1 in misbehaviour")
+	}
+	blockId2, err := ConvertToGnoBlockID(misbehaviour.Header2.SignedHeader.Commit.BlockId)
+	if err != nil {
+		return errorsmod.Wrap(err, "invalid block ID from header 2 in misbehaviour")
+	}
+	if err = blockId2.ValidateBasic(); err != nil {
 		return errorsmod.Wrap(err, "invalid block ID from header 2 in misbehaviour")
 	}
 

--- a/modules/10-gno/misbehaviour_handle.go
+++ b/modules/10-gno/misbehaviour_handle.go
@@ -55,12 +55,12 @@ func (ClientState) CheckForMisbehaviour(ctx sdk.Context, cdc codec.BinaryCodec, 
 		// if heights are equal check that this is valid misbehaviour of a fork
 		// otherwise if heights are unequal check that this is valid misbehavior of BFT time violation
 		if msg.Header1.GetHeight().EQ(msg.Header2.GetHeight()) {
-			blockID1 := ConvertToGnoBlockID(msg.Header1.SignedHeader.Commit.BlockId)
-			if blockID1.ValidateBasic() != nil {
+			blockID1, err := ConvertToGnoBlockID(msg.Header1.SignedHeader.Commit.BlockId)
+			if err != nil || blockID1.ValidateBasic() != nil {
 				return false
 			}
-			blockID2 := ConvertToGnoBlockID(msg.Header2.SignedHeader.Commit.BlockId)
-			if blockID2.ValidateBasic() != nil {
+			blockID2, err := ConvertToGnoBlockID(msg.Header2.SignedHeader.Commit.BlockId)
+			if err != nil || blockID2.ValidateBasic() != nil {
 				return false
 			}
 

--- a/modules/10-gno/misbehaviour_test.go
+++ b/modules/10-gno/misbehaviour_test.go
@@ -1,6 +1,7 @@
 package gno
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -214,6 +215,26 @@ func TestMisbehaviour_ValidateBasic_CommitBlockID(t *testing.T) {
 	err := misbehaviour.ValidateBasic()
 	require.NoError(t, err, "valid fork misbehaviour should pass ValidateBasic; "+
 		"if this fails, validCommit may be using Header.LastBlockId instead of Commit.BlockId")
+}
+
+// TestMisbehaviour_ValidateBasic_RejectsOversizedPrecommitPartsTotal ensures that a
+// precommit carrying a PartSetHeader.Total beyond the uint32 range is rejected with
+// an error at conversion instead of reaching the vendored CanonicalizePartSetHeader,
+// which panics on it while computing vote sign bytes during commit verification.
+func TestMisbehaviour_ValidateBasic_RejectsOversizedPrecommitPartsTotal(t *testing.T) {
+	blockTime := time.Now().UTC()
+	header1 := createTestHeader(t, testChainID, 100, clienttypes.NewHeight(1, 50), blockTime)
+	header2 := createTestHeader(t, testChainID, 100, clienttypes.NewHeight(1, 50), blockTime.Add(time.Second))
+
+	// Only the precommit is malformed; the commit block ID itself stays valid so
+	// the misbehaviour reaches commit verification.
+	header1.SignedHeader.Commit.Precommits[0].BlockId.PartsHeader.Total = math.MaxUint32 + 1
+
+	misbehaviour := NewMisbehaviour(testClientID, header1, header2)
+	var err error
+	require.NotPanics(t, func() { err = misbehaviour.ValidateBasic() })
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parts header total")
 }
 
 // TestCheckForMisbehaviour_ForkDetection tests that CheckForMisbehaviour

--- a/modules/10-gno/misbehaviour_test.go
+++ b/modules/10-gno/misbehaviour_test.go
@@ -219,7 +219,7 @@ func TestMisbehaviour_ValidateBasic_CommitBlockID(t *testing.T) {
 
 // TestMisbehaviour_ValidateBasic_RejectsOversizedPrecommitPartsTotal ensures that a
 // precommit carrying a PartSetHeader.Total beyond the uint32 range is rejected with
-// an error at conversion instead of reaching the vendored CanonicalizePartSetHeader,
+// an error at conversion instead of reaching gno's CanonicalizePartSetHeader,
 // which panics on it while computing vote sign bytes during commit verification.
 func TestMisbehaviour_ValidateBasic_RejectsOversizedPrecommitPartsTotal(t *testing.T) {
 	blockTime := time.Now().UTC()


### PR DESCRIPTION
## Summary

Two hardening fixes to the `10-gno` light client's protobuf-to-gno conversion layer in `modules/10-gno/helpers.go`, both reported through the bug bounty program and both classified as defense-in-depth rather than exploitable vulnerabilities. The first addresses report TMNSC-292, the second addresses report TMNSC-282.

### 1. Validator addresses were not bound to their public keys (TMNSC-292)

`ConvertToGnoValidatorSet` accepted any syntactically valid, unique address string for a validator without checking that it is derived from the validator's public key. Native gno enforces this binding in its validator set constructor (`validator address doesn't match pubkey`), so the light client diverged from gno's own validation.

Because `Validator.Bytes()` (and therefore `ValidatorSet.Hash()`) excludes the address, and commit sign bytes exclude the validator address and index, a relayer could attach distinct addresses to a single public key and have one signature counted in several slots of a relayer-supplied validator set.

The reported forgery only succeeds when the attacker already holds more than the configured trust level of the trusted validator set, under which a correct light client is forgeable by design (the new set is relayer-supplied and only bound by the header's validators hash). Below the trust level the missing check has no effect.

Changes:
- Require `address == pubkey.Address()` for every validator.
- Key the duplicate-address check on the parsed address instead of the raw string. bech32 decoding is case-insensitive, so two different strings can denote the same address.
- Reject ed25519 keys of the wrong length with an error instead of panicking on the slice-to-array conversion, and reject nil validator entries.

### 2. `PartSetHeader.Total` was not bounded before canonicalization (TMNSC-282)

The converters copied the protobuf `int64` `PartSetHeader.Total` into gno's `bfttypes.PartSetHeader` with a bare `int` cast and no bounds check, at four sites (commit block ID, each precommit block ID, header last block ID, and `ConvertToGnoBlockID`). None of the `ValidateBasic` paths cap it, since `PartSetHeader.ValidateBasic` is never invoked.

A precommit carrying a `Total` above the uint32 range therefore survived conversion and `Commit.ValidateBasic`, then panicked in gno's `CanonicalizePartSetHeader` when vote sign bytes were computed during commit verification. The panic is caught by the SDK's recovery middleware and surfaces as a deterministic transaction failure charged to the submitter, so there is no consensus or liveness impact. The upstream gno comment treats this panic as a fail-loud assertion and directs integrators to validate upstream, which is what this does.

Changes:
- Add `convertPartSetHeader`, enforcing the `[0, MaxBlockPartsCount]` bound and 32-byte-or-empty hash size that gno's `PartSetHeader.ValidateBasic` applies, and route all four cast sites through it. Out-of-range values now return a typed `ErrInvalidHeader`.
- `ConvertToGnoBlockID` now returns an error; both misbehaviour callers are updated.
- Reject a precommit `Type` that does not fit gno's byte-sized `SignedMsgType`, so the conversion cannot truncate an out-of-range wire value into the precommit type.

## State compatibility

These fixes are state-machine-breaking and must ship in a coordinated upgrade rather than as a patch release that nodes adopt independently. The changelog entries sit under State Breaking for that reason.

Behavior only differs for malformed client messages:

- A header whose validator addresses are not derived from their public keys was previously accepted and is now rejected.
- A header whose parts-header total is out of range previously failed with a recovered panic and now fails with a typed `ErrInvalidHeader`.

Legitimate gno headers are unaffected. Because the transaction error code and gas used feed into the results hash, a node on this binary and a node on the previous one would produce different results for such a message and diverge.

## Tests

Validator set binding, in `TestConvertToGnoValidatorSet_RejectsMalformedSets`:
- address not derived from pubkey (cross-checked against gno's `NewValidatorSet`, which panics on the same input)
- one pubkey under several distinct valid addresses (the reported set shape)
- duplicate address differing only in case
- pubkey with invalid length, no panic
- nil validator entry, no panic

Parts header bounds:
- `TestConvertPartSetHeader_Bounds` exercises every cast site with `-1`, `MaxBlockPartsCount + 1`, `MaxUint32 + 1` and `MaxInt64` (rejected, no panic), `0`, `1` and `MaxBlockPartsCount` (accepted), a 31-byte hash (rejected) and an empty hash (accepted).
- `TestConvertToGnoCommit_RejectsOutOfRangePrecommitType` shows the narrowing conversion alone would map 258 to the precommit type, and that the converter now rejects it.
- `TestMisbehaviour_ValidateBasic_RejectsOversizedPrecommitPartsTotal` reproduces the reported end-to-end path through `Misbehaviour.ValidateBasic`. It panics on `main` with `PartSetHeader.Total (4294967296) out of canonical uint32 range` and returns an error with this change.

All new cases fail on `main` and pass with this change. The full `modules/10-gno` suite and `make lint` pass.


